### PR TITLE
Suppress Warnings from realpath() if SAFE MODE is enabled

### DIFF
--- a/getid3/getid3.php
+++ b/getid3/getid3.php
@@ -32,7 +32,7 @@ if (!$temp_dir) {
 	// sys_get_temp_dir() may give inaccessible temp dir, e.g. with open_basedir on virtual hosts
 	$temp_dir = sys_get_temp_dir();
 }
-$temp_dir = realpath($temp_dir);
+$temp_dir = @realpath($temp_dir);
 $open_basedir = ini_get('open_basedir');
 if ($open_basedir) {
 	// e.g. "/var/www/vhosts/getid3.org/httpdocs/:/tmp/"


### PR DESCRIPTION
Suppress warnings like:
Warning: realpath() [function.realpath]: SAFE MODE Restriction in effect. The script whose uid is X is not allowed to access /tmp owned by uid 0 in .../getid3.php on line 22
