### PR TITLE
bugfix of a076a3ecee14ae5ca9b3b60dfdc0ba71c91bd7fe

### DIFF
--- a/getid3/write.id3v2.php
+++ b/getid3/write.id3v2.php
@@ -1544,7 +1544,7 @@ class getid3_write_id3v2
 						$frame_data = false;
 						if ($this->ID3v2FrameIsAllowed($frame_name, $source_data_array)) {
 							if(array_key_exists('description', $source_data_array) && array_key_exists('encodingid', $source_data_array) && array_key_exists('encoding', $this->tag_data)) {
-								$source_data_array['description'] = trim(getid3_lib::iconv_fallback($this->tag_data['encoding'], $source_data_array['encoding'], $source_data_array['description']));
+								$source_data_array['description'] = getid3_lib::iconv_fallback($this->tag_data['encoding'], $source_data_array['encoding'], $source_data_array['description']);
 							}
 							if ($frame_data = $this->GenerateID3v2FrameData($frame_name, $source_data_array)) {
 								$FrameUnsynchronisation = false;


### PR DESCRIPTION
The bugfix (G:22 ID3v2 TXXX description encoding) had a regression.
If you edit write a new tag in the file with merge_existing_data, the
description is not reencoded back to the original encoding, and the resulting
file is broken.

The issue with my fix is that you want to add a new TXXX with UTF-16 encoding
but use a default UTF-8 encoding, you have to encode description in UTF-8 and
the value in UTF-16

A better fix should be to change the original fix to alter only the decoded
frame, not the original ID3v2 one.
