### PR TITLE
Corrected merging of multiple genres for ID3v2.

### DIFF
--- a/getid3/getid3.lib.php
+++ b/getid3/getid3.lib.php
@@ -414,6 +414,20 @@ class getid3_lib
 		return $newarray;
 	}
 
+	public static function flipped_array_merge_noclobber($array1, $array2) {
+		if (!is_array($array1) || !is_array($array2)) {
+			return false;
+		}
+		# naturally, this only works non-recursively
+		$newarray = array_flip($array1);
+		foreach (array_flip($array2) as $key => $val) {
+			if (!isset($newarray[$key])) {
+				$newarray[$key] = count($newarray);
+			}
+		}
+		return array_flip($newarray);
+	}
+
 
 	public static function ksort_recursive(&$theArray) {
 		ksort($theArray);

--- a/getid3/module.tag.id3v2.php
+++ b/getid3/module.tag.id3v2.php
@@ -442,10 +442,12 @@ class getid3_id3v2 extends getid3_handler
 		} // end footer
 
 		if (isset($thisfile_id3v2['comments']['genre'])) {
+			$genre = array();
 			foreach ($thisfile_id3v2['comments']['genre'] as $key => $value) {
 				unset($thisfile_id3v2['comments']['genre'][$key]);
-				$thisfile_id3v2['comments'] = getid3_lib::array_merge_noclobber($thisfile_id3v2['comments'], array('genre'=>$this->ParseID3v2GenreString($value)));
+				$genre = getid3_lib::flipped_array_merge_noclobber($genre, $this->ParseID3v2GenreString($value));
 			}
+			$thisfile_id3v2['comments']['genre'] = getid3_lib::flipped_array_merge_noclobber($thisfile_id3v2['comments']['genre'], $genre);
 		}
 
 		if (isset($thisfile_id3v2['comments']['track'])) {


### PR DESCRIPTION
To me, the multiple genre processing is wrong because it tries to merge genre arrays together (using function array_merge_noclobber) on the basis of their index, not their content.

For example:

```
   [0] -> 'Trance'
```

merged with

```
   [0] -> 'Rock'
```

results in

```
   [0] -> 'Trance'
```

because the index is the same. But really, the content should be compared and added if not in the array yet, like this:

```
   [0] -> 'Trance',
   [1] -> 'Rock'
```

So I added a new merge function that should add new genres while increasing their index.
