### PR TITLE
Browsers unsupported MIME type "audio/x-wave"

### DIFF
--- a/getid3/getid3.php
+++ b/getid3/getid3.php
@@ -876,7 +876,7 @@ class getID3
 							'pattern'   => '^(RIFF|SDSS|FORM)',
 							'group'     => 'audio-video',
 							'module'    => 'riff',
-							'mime_type' => 'audio/x-wave',
+							'mime_type' => 'audio/x-wav',
 							'fail_ape'  => 'WARNING',
 						),
 


### PR DESCRIPTION
Browsers unsupported MIME type "audio/x-wave", typo may be . https://developer.mozilla.org/en-US/docs/Web/HTML/Supported_media_formats

<audio>
<source src="/audio/gr561e5529482ec964715652.wav?v20151019112911" type="audio/x-wave">
</audio>

WAV files does not play in the browsers with the "audio/x-wave" mime type