### PR TITLE
Fixed .gitignore comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,7 +110,9 @@ ClientBin
 stylecop.*
 ~$*
 *.dbmdl
-Generated_Code #added for RIA/Silverlight projects
+
+#added for RIA/Silverlight projects
+Generated_Code
 
 # Backup & report files from converting an old project file to a newer
 # Visual Studio version. Backup files are not needed, because we have git ;-)


### PR DESCRIPTION
Fixed .gitignore comments so it can be installed by composer / cached by satis.

Reference issue: https://github.com/composer/satis/issues/221