### PR TITLE
Fixed png analyzis when offset is greater than file chunk.

### DIFF
--- a/getid3/module.graphic.png.php
+++ b/getid3/module.graphic.png.php
@@ -45,7 +45,10 @@ class getid3_png extends getid3_handler
 		while ((($this->ftell() - (strlen($PNGfiledata) - $offset)) < $info['filesize'])) {
 			$chunk['data_length'] = getid3_lib::BigEndian2Int(substr($PNGfiledata, $offset, 4));
 			$offset += 4;
-			while (((strlen($PNGfiledata) - $offset) < ($chunk['data_length'] + 4)) && ($this->ftell() < $info['filesize'])) {
+			while ((strlen($PNGfiledata) > $offset)
+					&& ((strlen($PNGfiledata) - $offset) < ($chunk['data_length'] + 4))
+					&& ($this->ftell() < $info['filesize'])
+				) {
 				$PNGfiledata .= $this->fread($this->getid3->fread_buffer_size());
 			}
 			$chunk['type_text']   =               substr($PNGfiledata, $offset, 4);


### PR DESCRIPTION
Hi,

I have a big png file (25 MB) and getID3 can't parse it. It seems well formed, but this is hard to define precisely. Anyway, getID3 do an infinite loop in `module.graphic.png.php` because the `getid3_lib::BigEndian2Int()` used to get the data length of the chunk returns a boolean false that is not checked. I don't know if my patch is the better way to fix it (the result may be checked before), but it works. Anyway, the result should probably checked in the parsers used for other formats.

Sincerely,

Daniel Berthereau
Infodoc & Knowledge management