### PR TITLE
use mb_convert_encoding() instead of iconv()

### DIFF
--- a/getid3/getid3.lib.php
+++ b/getid3/getid3.lib.php
@@ -960,8 +960,20 @@ class getid3_lib
 			return $string;
 		}
 
+		// mb_convert_encoding() availble
+		if (function_exists('mb_convert_encoding')) {
+			if ($converted_string = @mb_convert_encoding($string, $out_charset, $in_charset)) {
+				switch ($out_charset) {
+					case 'ISO-8859-1':
+						$converted_string = rtrim($converted_string, "\x00");
+						break;
+				}
+				return $converted_string;
+			}
+			return $string;
+		}
 		// iconv() availble
-		if (function_exists('iconv')) {
+		else if (function_exists('iconv')) {
 			if ($converted_string = @iconv($in_charset, $out_charset.'//TRANSLIT', $string)) {
 				switch ($out_charset) {
 					case 'ISO-8859-1':
@@ -977,7 +989,7 @@ class getid3_lib
 		}
 
 
-		// iconv() not available
+		// neither mb_convert_encoding or iconv() is available
 		static $ConversionFunctionList = array();
 		if (empty($ConversionFunctionList)) {
 			$ConversionFunctionList['ISO-8859-1']['UTF-8']    = 'iconv_fallback_iso88591_utf8';
@@ -999,7 +1011,7 @@ class getid3_lib
 			$ConversionFunction = $ConversionFunctionList[strtoupper($in_charset)][strtoupper($out_charset)];
 			return self::$ConversionFunction($string);
 		}
-		throw new Exception('PHP does not have iconv() support - cannot convert from '.$in_charset.' to '.$out_charset);
+		throw new Exception('PHP does not has mb_convert_encoding() or iconv() support - cannot convert from '.$in_charset.' to '.$out_charset);
 	}
 
 	public static function recursiveMultiByteCharString2HTML($data, $charset='ISO-8859-1') {

--- a/getid3/getid3.lib.php
+++ b/getid3/getid3.lib.php
@@ -960,9 +960,9 @@ class getid3_lib
 			return $string;
 		}
 
-		// iconv() availble
-		if (function_exists('iconv')) {
-			if ($converted_string = @iconv($in_charset, $out_charset.'//TRANSLIT', $string)) {
+		// mb_convert_encoding() availble
+		if (function_exists('mb_convert_encoding')) {
+			if ($converted_string = mb_convert_encoding($string, $out_charset, $in_charset)) {
 				switch ($out_charset) {
 					case 'ISO-8859-1':
 						$converted_string = rtrim($converted_string, "\x00");
@@ -977,7 +977,7 @@ class getid3_lib
 		}
 
 
-		// iconv() not available
+		// mb_convert_encoding() not available
 		static $ConversionFunctionList = array();
 		if (empty($ConversionFunctionList)) {
 			$ConversionFunctionList['ISO-8859-1']['UTF-8']    = 'iconv_fallback_iso88591_utf8';
@@ -999,7 +999,7 @@ class getid3_lib
 			$ConversionFunction = $ConversionFunctionList[strtoupper($in_charset)][strtoupper($out_charset)];
 			return self::$ConversionFunction($string);
 		}
-		throw new Exception('PHP does not have iconv() support - cannot convert from '.$in_charset.' to '.$out_charset);
+		throw new Exception('PHP does not have mb_convert_encoding() support - cannot convert from '.$in_charset.' to '.$out_charset);
 	}
 
 	public static function recursiveMultiByteCharString2HTML($data, $charset='ISO-8859-1') {

--- a/getid3/getid3.lib.php
+++ b/getid3/getid3.lib.php
@@ -960,9 +960,9 @@ class getid3_lib
 			return $string;
 		}
 
-		// mb_convert_encoding() availble
-		if (function_exists('mb_convert_encoding')) {
-			if ($converted_string = mb_convert_encoding($string, $out_charset, $in_charset)) {
+		// iconv() availble
+		if (function_exists('iconv')) {
+			if ($converted_string = @iconv($in_charset, $out_charset.'//TRANSLIT', $string)) {
 				switch ($out_charset) {
 					case 'ISO-8859-1':
 						$converted_string = rtrim($converted_string, "\x00");
@@ -977,7 +977,7 @@ class getid3_lib
 		}
 
 
-		// mb_convert_encoding() not available
+		// iconv() not available
 		static $ConversionFunctionList = array();
 		if (empty($ConversionFunctionList)) {
 			$ConversionFunctionList['ISO-8859-1']['UTF-8']    = 'iconv_fallback_iso88591_utf8';
@@ -999,7 +999,7 @@ class getid3_lib
 			$ConversionFunction = $ConversionFunctionList[strtoupper($in_charset)][strtoupper($out_charset)];
 			return self::$ConversionFunction($string);
 		}
-		throw new Exception('PHP does not have mb_convert_encoding() support - cannot convert from '.$in_charset.' to '.$out_charset);
+		throw new Exception('PHP does not have iconv() support - cannot convert from '.$in_charset.' to '.$out_charset);
 	}
 
 	public static function recursiveMultiByteCharString2HTML($data, $charset='ISO-8859-1') {

--- a/getid3/getid3.php
+++ b/getid3/getid3.php
@@ -426,14 +426,14 @@ class getID3
 				return $this->error('Format not supported, module "'.$determined_format['include'].'" was removed.');
 			}
 
-			// module requires iconv support
+			// module requires mb_convert_encoding/iconv support
 			// Check encoding/iconv support
-			if (!empty($determined_format['iconv_req']) && !function_exists('iconv') && !in_array($this->encoding, array('ISO-8859-1', 'UTF-8', 'UTF-16LE', 'UTF-16BE', 'UTF-16'))) {
-				$errormessage = 'iconv() support is required for this module ('.$determined_format['include'].') for encodings other than ISO-8859-1, UTF-8, UTF-16LE, UTF16-BE, UTF-16. ';
+			if (!empty($determined_format['iconv_req']) && !function_exists('mb_convert_encoding') && !function_exists('iconv') && !in_array($this->encoding, array('ISO-8859-1', 'UTF-8', 'UTF-16LE', 'UTF-16BE', 'UTF-16'))) {
+				$errormessage = 'mb_convert_encoding() or iconv() support is required for this module ('.$determined_format['include'].') for encodings other than ISO-8859-1, UTF-8, UTF-16LE, UTF16-BE, UTF-16. ';
 				if (GETID3_OS_ISWINDOWS) {
-					$errormessage .= 'PHP does not have iconv() support. Please enable php_iconv.dll in php.ini, and copy iconv.dll from c:/php/dlls to c:/windows/system32';
+					$errormessage .= 'PHP does not have mb_convert_encoding() or iconv() support. Please enable php_mbstring.dll / php_iconv.dll in php.ini, and copy php_mbstring.dll / iconv.dll from c:/php/dlls to c:/windows/system32';
 				} else {
-					$errormessage .= 'PHP is not compiled with iconv() support. Please recompile with the --with-iconv switch';
+					$errormessage .= 'PHP is not compiled with mb_convert_encoding() or iconv() support. Please recompile with the --enable-mbstring / --with-iconv switch';
 				}
 				return $this->error($errormessage);
 			}
@@ -1248,7 +1248,21 @@ class getID3
 				// Since ID3v1 has no concept of character sets there is no certain way to know we have the correct non-ISO-8859-1 character set, but we can guess
 				if ($comment_name == 'id3v1') {
 					if ($encoding == 'ISO-8859-1') {
-						if (function_exists('iconv')) {
+						if (function_exists('mb_convert_encoding')) {
+							foreach ($this->info['tags'][$tag_name] as $tag_key => $valuearray) {
+								foreach ($valuearray as $key => $value) {
+									if (preg_match('#^[\\x80-\\xFF]+$#', $value)) {
+										foreach (array('windows-1251', 'KOI8-R') as $id3v1_bad_encoding) {
+											if (@mb_convert_encoding($value, $id3v1_bad_encoding, $id3v1_bad_encoding) === $value) {
+												$encoding = $id3v1_bad_encoding;
+												break 3;
+											}
+										}
+									}
+								}
+							}
+						}
+						else if (function_exists('iconv')) {
 							foreach ($this->info['tags'][$tag_name] as $tag_key => $valuearray) {
 								foreach ($valuearray as $key => $value) {
 									if (preg_match('#^[\\x80-\\xFF]+$#', $value)) {

--- a/getid3/getid3.php
+++ b/getid3/getid3.php
@@ -72,7 +72,7 @@ unset($open_basedir, $temp_dir);
 class getID3
 {
 	// public: Settings
-	public $encoding        = 'UTF-8';        // CASE SENSITIVE! - i.e. (must be supported by iconv()). Examples:  ISO-8859-1  UTF-8  UTF-16  UTF-16BE
+	public $encoding        = 'UTF-8';        // CASE SENSITIVE! - i.e. (must be supported by mb_convert_encoding()). Examples:  ISO-8859-1  UTF-8  UTF-16  UTF-16BE
 	public $encoding_id3v1  = 'ISO-8859-1';   // Should always be 'ISO-8859-1', but some tags may be written in other encodings such as 'EUC-CN' or 'CP1252'
 
 	// public: Optional tag checks - disable for speed.
@@ -428,12 +428,12 @@ class getID3
 
 			// module requires iconv support
 			// Check encoding/iconv support
-			if (!empty($determined_format['iconv_req']) && !function_exists('iconv') && !in_array($this->encoding, array('ISO-8859-1', 'UTF-8', 'UTF-16LE', 'UTF-16BE', 'UTF-16'))) {
-				$errormessage = 'iconv() support is required for this module ('.$determined_format['include'].') for encodings other than ISO-8859-1, UTF-8, UTF-16LE, UTF16-BE, UTF-16. ';
+			if (!empty($determined_format['iconv_req']) && !function_exists('mb_convert_encoding') && !in_array($this->encoding, array('ISO-8859-1', 'UTF-8', 'UTF-16LE', 'UTF-16BE', 'UTF-16'))) {
+				$errormessage = 'mb_convert_encoding() support is required for this module ('.$determined_format['include'].') for encodings other than ISO-8859-1, UTF-8, UTF-16LE, UTF16-BE, UTF-16. ';
 				if (GETID3_OS_ISWINDOWS) {
-					$errormessage .= 'PHP does not have iconv() support. Please enable php_iconv.dll in php.ini, and copy iconv.dll from c:/php/dlls to c:/windows/system32';
+					$errormessage .= 'PHP does not have mb_convert_encoding() support. Please enable php_iconv.dll in php.ini, and copy iconv.dll from c:/php/dlls to c:/windows/system32';
 				} else {
-					$errormessage .= 'PHP is not compiled with iconv() support. Please recompile with the --with-iconv switch';
+					$errormessage .= 'PHP is not compiled with mb_convert_encoding() support. Please recompile with the --with-iconv switch';
 				}
 				return $this->error($errormessage);
 			}
@@ -1248,12 +1248,12 @@ class getID3
 				// Since ID3v1 has no concept of character sets there is no certain way to know we have the correct non-ISO-8859-1 character set, but we can guess
 				if ($comment_name == 'id3v1') {
 					if ($encoding == 'ISO-8859-1') {
-						if (function_exists('iconv')) {
+						if (function_exists('mb_convert_encoding')) {
 							foreach ($this->info['tags'][$tag_name] as $tag_key => $valuearray) {
 								foreach ($valuearray as $key => $value) {
 									if (preg_match('#^[\\x80-\\xFF]+$#', $value)) {
 										foreach (array('windows-1251', 'KOI8-R') as $id3v1_bad_encoding) {
-											if (@iconv($id3v1_bad_encoding, $id3v1_bad_encoding, $value) === $value) {
+											if (mb_convert_encoding($value, $id3v1_bad_encoding, $id3v1_bad_encoding) === $value) {
 												$encoding = $id3v1_bad_encoding;
 												break 3;
 											}

--- a/getid3/getid3.php
+++ b/getid3/getid3.php
@@ -72,7 +72,7 @@ unset($open_basedir, $temp_dir);
 class getID3
 {
 	// public: Settings
-	public $encoding        = 'UTF-8';        // CASE SENSITIVE! - i.e. (must be supported by mb_convert_encoding()). Examples:  ISO-8859-1  UTF-8  UTF-16  UTF-16BE
+	public $encoding        = 'UTF-8';        // CASE SENSITIVE! - i.e. (must be supported by iconv()). Examples:  ISO-8859-1  UTF-8  UTF-16  UTF-16BE
 	public $encoding_id3v1  = 'ISO-8859-1';   // Should always be 'ISO-8859-1', but some tags may be written in other encodings such as 'EUC-CN' or 'CP1252'
 
 	// public: Optional tag checks - disable for speed.
@@ -428,12 +428,12 @@ class getID3
 
 			// module requires iconv support
 			// Check encoding/iconv support
-			if (!empty($determined_format['iconv_req']) && !function_exists('mb_convert_encoding') && !in_array($this->encoding, array('ISO-8859-1', 'UTF-8', 'UTF-16LE', 'UTF-16BE', 'UTF-16'))) {
-				$errormessage = 'mb_convert_encoding() support is required for this module ('.$determined_format['include'].') for encodings other than ISO-8859-1, UTF-8, UTF-16LE, UTF16-BE, UTF-16. ';
+			if (!empty($determined_format['iconv_req']) && !function_exists('iconv') && !in_array($this->encoding, array('ISO-8859-1', 'UTF-8', 'UTF-16LE', 'UTF-16BE', 'UTF-16'))) {
+				$errormessage = 'iconv() support is required for this module ('.$determined_format['include'].') for encodings other than ISO-8859-1, UTF-8, UTF-16LE, UTF16-BE, UTF-16. ';
 				if (GETID3_OS_ISWINDOWS) {
-					$errormessage .= 'PHP does not have mb_convert_encoding() support. Please enable php_iconv.dll in php.ini, and copy iconv.dll from c:/php/dlls to c:/windows/system32';
+					$errormessage .= 'PHP does not have iconv() support. Please enable php_iconv.dll in php.ini, and copy iconv.dll from c:/php/dlls to c:/windows/system32';
 				} else {
-					$errormessage .= 'PHP is not compiled with mb_convert_encoding() support. Please recompile with the --with-iconv switch';
+					$errormessage .= 'PHP is not compiled with iconv() support. Please recompile with the --with-iconv switch';
 				}
 				return $this->error($errormessage);
 			}
@@ -1248,12 +1248,12 @@ class getID3
 				// Since ID3v1 has no concept of character sets there is no certain way to know we have the correct non-ISO-8859-1 character set, but we can guess
 				if ($comment_name == 'id3v1') {
 					if ($encoding == 'ISO-8859-1') {
-						if (function_exists('mb_convert_encoding')) {
+						if (function_exists('iconv')) {
 							foreach ($this->info['tags'][$tag_name] as $tag_key => $valuearray) {
 								foreach ($valuearray as $key => $value) {
 									if (preg_match('#^[\\x80-\\xFF]+$#', $value)) {
 										foreach (array('windows-1251', 'KOI8-R') as $id3v1_bad_encoding) {
-											if (mb_convert_encoding($value, $id3v1_bad_encoding, $id3v1_bad_encoding) === $value) {
+											if (@iconv($id3v1_bad_encoding, $id3v1_bad_encoding, $value) === $value) {
 												$encoding = $id3v1_bad_encoding;
 												break 3;
 											}


### PR DESCRIPTION
http://php.net/manual/en/book.iconv.php

Remember that the underlying library (libiconv) is basically not maintained anymore.

Iconv is badly supported by any php images from docker, but works with mb_convert_encoding. So I suggest to use use mb_convert_encoding() instead of iconv().