### PR TITLE
Can't specify value for the 'GRID' tag

### DIFF
--- a/getid3/write.php
+++ b/getid3/write.php
@@ -508,6 +508,19 @@ throw new Exception('$this->overwrite_tags=false is known to be buggy in this ve
 					}
 					break;
 
+				case 'GRID':
+					if (
+						isset($valuearray['groupsymbol']) &&
+						isset($valuearray['ownerid']) &&
+						isset($valuearray['data'])
+					) {
+							$tag_data_id3v2['GRID'][] = $valuearray;
+					} else {
+						$this->errors[] = 'ID3v2 GRID data is not properly structured';
+						return false;
+					}
+					break;
+
 				case 'UFID':
 					if (isset($valuearray['ownerid']) &&
 						isset($valuearray['data'])) {


### PR DESCRIPTION
If you specify a `GRID` tag (below), it doesn't get sent through the tag writer class correctly. The `FormatDataForID3v2()` function attempts to format each array item as a separate tag.

This PR should fix that.

```php
<?php
        $tagData = [
            // GRID.
            'group_identification_registration' => [
                'ownerid' => '123123',
                'groupsymbol' => '',
                'data' => '',
            ],
        ];
```