### PR TITLE
Add support for gs:// urls (Google App Engine)

### DIFF
--- a/getid3/getid3.php
+++ b/getid3/getid3.php
@@ -277,7 +277,7 @@ class getID3
 			}
 
 			$filename = str_replace('/', DIRECTORY_SEPARATOR, $filename);
-			$filename = preg_replace('#(.+)'.preg_quote(DIRECTORY_SEPARATOR).'{2,}#U', '\1'.DIRECTORY_SEPARATOR, $filename);
+			$filename = preg_replace('#(?:gs://)??(.+)'.preg_quote(DIRECTORY_SEPARATOR).'{2,}#U', '\1'.DIRECTORY_SEPARATOR, $filename);
 
 			// open local file
 			//if (is_readable($filename) && is_file($filename) && ($this->fp = fopen($filename, 'rb'))) { // see http://www.getid3.org/phpBB3/viewtopic.php?t=1720

--- a/getid3/getid3.php
+++ b/getid3/getid3.php
@@ -277,7 +277,7 @@ class getID3
 			}
 
 			$filename = str_replace('/', DIRECTORY_SEPARATOR, $filename);
-			$filename = preg_replace('#(?:gs://)??(.+)'.preg_quote(DIRECTORY_SEPARATOR).'{2,}#U', '\1'.DIRECTORY_SEPARATOR, $filename);
+			$filename = preg_replace('#(?<!gs:)('.preg_quote(DIRECTORY_SEPARATOR).'{2,})#', DIRECTORY_SEPARATOR, $filename);
 
 			// open local file
 			//if (is_readable($filename) && is_file($filename) && ($this->fp = fopen($filename, 'rb'))) { // see http://www.getid3.org/phpBB3/viewtopic.php?t=1720


### PR DESCRIPTION
Google App Engine uses its own pseudo protocol identifier for files that can be read/write directly from a bucket (e.g. storage): https://cloud.google.com/appengine/docs/standard/php/googlestorage/

This PR will allow those type of filenames that would otherwise be stripped (e.g. `gs:/` vs `gs://`) - according to my naive regex testing it should work out 😛 : https://regex101.com/r/G7SfAa/2