### PR TITLE
Replace PHP4 constructor

### DIFF
--- a/demos/demo.audioinfo.class.php
+++ b/demos/demo.audioinfo.class.php
@@ -58,7 +58,7 @@ class AudioInfo {
 	* Constructor
 	*/
 
-	function AudioInfo() {
+	function __construct() {
 
 		// Initialize getID3 engine
 		$this->getID3 = new getID3;


### PR DESCRIPTION
Min supported PHP version is PHP 5.3, we don't need a PHP 4 constructor in example code :)