### PR TITLE
Fix deprecated license names

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "homepage": "http://www.getid3.org/",
     "keywords": ["php","tags","codecs"],
     "type": "library",
-    "license": "GPL",
+    "license": ["GPL-1.0-or-later", "LGPL-3.0-only", "MPL-2.0"],
     "require":
     {
         "php": ">=5.3.0"


### PR DESCRIPTION
Major change was implemented in the latest Composer version, which deprecated the GPL license identifier.