### PR TITLE
Fixes for MPEG-2 aspect ratio detection

### DIFF
--- a/getid3/module.audio-video.mpeg.php
+++ b/getid3/module.audio-video.mpeg.php
@@ -149,12 +149,6 @@ class getid3_mpeg extends getid3_handler
 				case 0xB5: // extension_start_code
 					$info['video']['codec'] = 'MPEG-2';
 
-					if (isset($info['mpeg']['video']['raw']['aspect_ratio_information'])) {
-						// MPEG-2 defines the aspect ratio flag differently from MPEG-1, but the MPEG-2 extension start code may occur after we've already looked up the aspect ratio assuming it was MPEG-1, so re-lookup assuming MPEG-2
-						$info['mpeg']['video']['pixel_aspect_ratio']      =     self::videoAspectRatioLookup($info['mpeg']['video']['raw']['aspect_ratio_information'], 2);
-						$info['mpeg']['video']['pixel_aspect_ratio_text'] = self::videoAspectRatioTextLookup($info['mpeg']['video']['raw']['aspect_ratio_information'], 2);
-					}
-
 					$bitstream = getid3_lib::BigEndian2Bin(substr($MPEGstreamData, $StartCodeOffset + 4, 8)); // 48 bits for Sequence Extension ID; 61 bits for Sequence Display Extension ID; 59 bits for Sequence Scalable Extension ID
 					$bitstreamoffset = 0;
 
@@ -179,6 +173,16 @@ class getid3_mpeg extends getid3_handler
 							$info['video']['interlaced']            = !$info['mpeg']['video']['raw']['progressive_sequence'];
 							$info['mpeg']['video']['interlaced']    = !$info['mpeg']['video']['raw']['progressive_sequence'];
 							$info['mpeg']['video']['chroma_format'] = self::chromaFormatTextLookup($info['mpeg']['video']['raw']['chroma_format']);
+
+							if (isset($info['mpeg']['video']['raw']['aspect_ratio_information'])) {
+								// MPEG-2 defines the aspect ratio flag differently from MPEG-1, but the MPEG-2 extension start code may occur after we've already looked up the aspect ratio assuming it was MPEG-1, so re-lookup assuming MPEG-2
+								// This must be done after the extended size is known, so the display aspect ratios can be converted to pixel aspect ratios.
+								$info['mpeg']['video']['pixel_aspect_ratio']      =     self::videoAspectRatioLookup($info['mpeg']['video']['raw']['aspect_ratio_information'], 2, $info['video']['resolution_x'], $info['video']['resolution_y']);
+								$info['mpeg']['video']['pixel_aspect_ratio_text'] = self::videoAspectRatioTextLookup($info['mpeg']['video']['raw']['aspect_ratio_information'], 2);
+								$info['video']['pixel_aspect_ratio'] = $info['mpeg']['video']['pixel_aspect_ratio'];
+								$info['video']['pixel_aspect_ratio_text'] = $info['mpeg']['video']['pixel_aspect_ratio_text'];
+							}
+
 							break;
 
 						case  2: // 0010 Sequence Display Extension ID
@@ -601,12 +605,17 @@ echo 'average_File_bitrate = '.number_format(array_sum($vbr_bitrates) / count($v
 	 *
 	 * @return float
 	 */
-	public static function videoAspectRatioLookup($rawaspectratio, $mpeg_version=1) {
+	public static function videoAspectRatioLookup($rawaspectratio, $mpeg_version=1, $width=0, $height=0) {
 		$lookup = array(
 			1 => array(0, 1, 0.6735, 0.7031, 0.7615, 0.8055, 0.8437, 0.8935, 0.9157, 0.9815, 1.0255, 1.0695, 1.0950, 1.1575, 1.2015, 0),
 			2 => array(0, 1, 1.3333, 1.7778, 2.2100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
 		);
-		return (float) (isset($lookup[$rawaspectratio][$mpeg_version]) ? $lookup[$rawaspectratio][$mpeg_version] : 0);
+		$ratio = (float) (isset($lookup[$mpeg_version][$rawaspectratio]) ? $lookup[$mpeg_version][$rawaspectratio] : 0);
+		if ($mpeg_version == 2 && $ratio != 1) {
+			// Calculate pixel aspect ratio from MPEG-2 display aspect ratio
+			$ratio = $ratio * $height / $width;
+		}
+		return $ratio;
 	}
 
 	/**
@@ -617,9 +626,9 @@ echo 'average_File_bitrate = '.number_format(array_sum($vbr_bitrates) / count($v
 	public static function videoAspectRatioTextLookup($rawaspectratio, $mpeg_version=1) {
 		$lookup = array(
 			1 => array('forbidden', 'square pixels', '0.6735', '16:9, 625 line, PAL', '0.7615', '0.8055', '16:9, 525 line, NTSC', '0.8935', '4:3, 625 line, PAL, CCIR601', '0.9815', '1.0255', '1.0695', '4:3, 525 line, NTSC, CCIR601', '1.1575', '1.2015', 'reserved'),
-			2 => array('forbidden', 'square pixels', '4:3', '16:9', '1.21:1', 'reserved', 'reserved', 'reserved', 'reserved', 'reserved', 'reserved', 'reserved', 'reserved', 'reserved', 'reserved', 'reserved'), // http://dvd.sourceforge.net/dvdinfo/mpeghdrs.html
+			2 => array('forbidden', 'square pixels', '4:3', '16:9', '2.21:1', 'reserved', 'reserved', 'reserved', 'reserved', 'reserved', 'reserved', 'reserved', 'reserved', 'reserved', 'reserved', 'reserved'), // http://dvd.sourceforge.net/dvdinfo/mpeghdrs.html
 		);
-		return (isset($lookup[$rawaspectratio][$mpeg_version]) ? $lookup[$rawaspectratio][$mpeg_version] : '');
+		return (isset($lookup[$mpeg_version][$rawaspectratio]) ? $lookup[$mpeg_version][$rawaspectratio] : '');
 	}
 
 	/**


### PR DESCRIPTION
* fix array lookup
* calculate pixel aspect ratio from display aspect ratios
* delay calc of aspect ratio until after extended size is known
* mirror the updated pixel aspect ratio up to the 'video' section

Fixes remaining issues with https://github.com/JamesHeinrich/getID3/issues/148