### PR TITLE
Add more image formats supported by getimagesize()

### DIFF
--- a/getid3/getid3.lib.php
+++ b/getid3/getid3.lib.php
@@ -1602,6 +1602,10 @@ class getid3_lib
 			$ImageTypesLookup[12] = 'jb2';
 			$ImageTypesLookup[13] = 'swc';
 			$ImageTypesLookup[14] = 'iff';
+			$ImageTypesLookup[15] = 'wbmp';
+			$ImageTypesLookup[16] = 'xbm';
+			$ImageTypesLookup[17] = 'ico';
+			$ImageTypesLookup[18] = 'webp';
 		}
 		return (isset($ImageTypesLookup[$imagetypeid]) ? $ImageTypesLookup[$imagetypeid] : '');
 	}


### PR DESCRIPTION
See https://3v4l.org/A1PTC
This function was only used here (and in demo.browse.php)
https://github.com/JamesHeinrich/getID3/blob/19bb4c8440119772ce4ed5007e61f0e64dc7e8d3/getid3/module.tag.id3v2.php#L1449-L1451
We can notice that for some types of images it returns the wrong mime type ("image/swf", "image/bmp", etc.). I'm not sure whether to add only this change, or even replace the whole function with image_type_to_mime_type() (it was used in other modules).