### PR TITLE
Replace getid3_lib::ImageTypesLookup() with image_type_to_mime_type()

### DIFF
--- a/getid3/module.tag.id3v2.php
+++ b/getid3/module.tag.id3v2.php
@@ -1447,7 +1447,7 @@ class getid3_id3v2 extends getid3_handler
 				$imageinfo = array();
 				if ($imagechunkcheck = getid3_lib::GetDataImageSize($parsedFrame['data'], $imageinfo)) {
 					if (($imagechunkcheck[2] >= 1) && ($imagechunkcheck[2] <= 3)) {
-						$parsedFrame['image_mime']       = 'image/'.getid3_lib::ImageTypesLookup($imagechunkcheck[2]);
+						$parsedFrame['image_mime']       = image_type_to_mime_type($imagechunkcheck[2]);
 						if ($imagechunkcheck[0]) {
 							$parsedFrame['image_width']  = $imagechunkcheck[0];
 						}


### PR DESCRIPTION
Possible breaks after this change:

Old MIME type | New MIME type
------------- | --------------
`image/swf` | `application/x-shockwave-flash`
`image/bmp` | `image/x-ms-bmp`
`image/tiff (little-endian)` | `image/tiff`
`image/tiff (big-endian)` | `image/tiff`
`image/jpc` | `application/octet-stream`
`image/jpx` | `application/octet-stream`
`image/jb2` | `application/octet-stream`
`image/swc` | `application/x-shockwave-flash`
`image/wbmp` | `image/vnd.wap.wbmp`
`image/ico` | `image/vnd.microsoft.icon`
