### PR TITLE
Branch-alias for dev-master and https redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 getID3() by James Heinrich (<info@getid3.org>)
 ===
-**Available at <http://getid3.sourceforge.net> or <http://www.getid3.org>**
+**Available at <http://getid3.sourceforge.net> or <https://www.getid3.org>**
 
 getID3() is released under multiple licenses. You may choose from the following licenses, and use getID3 according to the terms of the license most suitable to your project.
 
@@ -18,17 +18,17 @@ getID3() is released under multiple licenses. You may choose from the following 
 
 **Mozilla MPL:**
 
-* [v2](http://www.mozilla.org/MPL/2.0/)
+* [v2](https://www.mozilla.org/MPL/2.0/)
 
 **getID3 Commercial License:**
 
-* [gCL](http://getid3.org/#gCL) (payment required)
+* [gCL](https://www.getid3.org/#gCL) (payment required)
 
 * * *
 Copies of each of the above licenses are included in the `licenses/`
 directory of the getID3 distribution.
 
-If you want to donate, there is a link on <http://www.getid3.org> for PayPal donations.
+If you want to donate, there is a link on <https://www.getid3.org> for PayPal donations.
 
 
 
@@ -294,7 +294,7 @@ function getID3($filename) { return unpack('a3TAG/a30title/a30artist/a30album/a4
 
 Future Plans
 ===
-<http://www.getid3.org/phpBB3/viewforum.php?f=7>
+<https://www.getid3.org/phpBB3/viewforum.php?f=7>
 
 * Better support for MP4 container format
 * Scan for appended ID3v2 tag at end of file per ID3v2.4 specs (Section 5.0)
@@ -336,11 +336,11 @@ Future Plans
 * Optional scan-through-frames for AVI verification
   (thanks rockcohenØmassive-interactive*nl)
 * Support for TTF (thanks infoØbutterflyx*com)
-* Support for DSS (http://www.getid3.org/phpBB3/viewtopic.php?t=171)
+* Support for DSS (https://www.getid3.org/phpBB3/viewtopic.php?t=171)
 * Support for SMAF (http://smaf-yamaha.com/what/demo.html)
-  http://www.getid3.org/phpBB3/viewtopic.php?t=182
-* Support for AMR (http://www.getid3.org/phpBB3/viewtopic.php?t=195)
-* Support for 3gpp (http://www.getid3.org/phpBB3/viewtopic.php?t=195)
+  https://www.getid3.org/phpBB3/viewtopic.php?t=182
+* Support for AMR (https://www.getid3.org/phpBB3/viewtopic.php?t=195)
+* Support for 3gpp (https://www.getid3.org/phpBB3/viewtopic.php?t=195)
 * Support for ID4 (http://www.wackysoft.cjb.net grizlyY2KØhotmail*com)
 * Parse XML data returned in Ogg comments
 * Parse XML data from Quicktime SMIL metafiles (klausrathØmac*com)
@@ -376,7 +376,7 @@ Future Plans
 
 Known Bugs/Issues in getID3() that may be fixed eventually
 ===
-<http://www.getid3.org/phpBB3/viewtopic.php?t=25>
+<https://www.getid3.org/phpBB3/viewtopic.php?t=25>
 
 * Cannot determine bitrate for MPEG video with VBR video data
   (need documentation)
@@ -402,7 +402,7 @@ Known Bugs/Issues in getID3() that may be fixed eventually
 
 Known Bugs/Issues in getID3() that cannot be fixed
 ---
-<http://www.getid3.org/phpBB3/viewtopic.php?t=25>
+<https://www.getid3.org/phpBB3/viewtopic.php?t=25>
 
 * 32-bit PHP installations only:
   Files larger than 2GB cannot always be parsed fully by getID3()
@@ -432,7 +432,7 @@ Known Bugs/Issues in getID3() that cannot be fixed
 
 Known Bugs/Issues in other programs
 ---
-<http://www.getid3.org/phpBB3/viewtopic.php?t=25>
+<https://www.getid3.org/phpBB3/viewtopic.php?t=25>
 
 * Windows Media Player (up to v11) and iTunes (up to v10+) do
     not correctly handle ID3v2.3 tags with UTF-16BE+BOM

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 //                                                             //
@@ -574,7 +574,7 @@ Version History
     » Tagwriter requires metaflac 1.1.1+ in order to write FLAC tags.
     » Removed broken and non-fixable tagwriting module for real format.
     ! Developers please help fix the above module:
-      http://www.getid3.org/phpBB3/viewtopic.php?t=677
+      https://www.getid3.org/phpBB3/viewtopic.php?t=677
     » Avoided security issues with demo.browse.php, demo.write.php and
       demo.mysql.php. These demos are now disabled by default and has
       to be enabled in the source.
@@ -1438,7 +1438,7 @@ Version History
 
 
 1.6.2: [May-04-2003] James Heinrich
-   » New official mirror site for getID3() - http://www.getid3.org
+   » New official mirror site for getID3() - https://www.getid3.org
    » Added basic support for SWF (Flash)  (thanks n8n8Øyahoo*com)
      New file: getid3.swf.php
    » Added experimental support for parsing the audio portion of

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,7 @@
     "keywords": ["php","tags","codecs"],
     "type": "library",
     "license": ["GPL-1.0-or-later", "LGPL-3.0-only", "MPL-2.0"],
-    "require":
-    {
+    "require": {
         "php": ">=5.3.0"
     },
     "require-dev": {
@@ -20,5 +19,10 @@
     },
     "autoload": {
         "classmap": ["getid3/"]
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.9.x-dev"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "james-heinrich/getid3",
     "description": "PHP script that extracts useful information from popular multimedia file formats",
-    "homepage": "http://www.getid3.org/",
+    "homepage": "https://www.getid3.org/",
     "keywords": ["php","tags","codecs"],
     "type": "library",
     "license": ["GPL-1.0-or-later", "LGPL-3.0-only", "MPL-2.0"],

--- a/demos/demo.basic.php
+++ b/demos/demo.basic.php
@@ -2,7 +2,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 //                                                             //

--- a/demos/demo.browse.php
+++ b/demos/demo.browse.php
@@ -2,7 +2,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 //                                                             //
@@ -603,7 +603,7 @@ function MoreNaturalSort($ar1, $ar2) {
 function PoweredBygetID3($string='') {
 	global $getID3;
 	if (!$string) {
-		$string = '<div style="border: 1px #CCCCCC solid; padding: 5px; margin: 5px 0; float: left; background-color: #EEEEEE; font-size: 8pt; font-family: sans-serif;">Powered by <a href="http://www.getid3.org/"><b>getID3() v<!--GETID3VER--></b><br>http://www.getid3.org/</a><br>Running on PHP v'.PHP_VERSION.' ('.(8 * PHP_INT_SIZE).'-bit, '.(defined('PHP_OS_FAMILY') ? PHP_OS_FAMILY : PHP_OS).')</div>';
+		$string = '<div style="border: 1px #CCCCCC solid; padding: 5px; margin: 5px 0; float: left; background-color: #EEEEEE; font-size: 8pt; font-family: sans-serif;">Powered by <a href="https://www.getid3.org/"><b>getID3() v<!--GETID3VER--></b><br>https://www.getid3.org/</a><br>Running on PHP v'.PHP_VERSION.' ('.(8 * PHP_INT_SIZE).'-bit, '.(defined('PHP_OS_FAMILY') ? PHP_OS_FAMILY : PHP_OS).')</div>';
 	}
 	return str_replace('<!--GETID3VER-->', $getID3->version(), $string);
 }

--- a/demos/demo.cache.dbm.php
+++ b/demos/demo.cache.dbm.php
@@ -2,7 +2,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 //                                                             //

--- a/demos/demo.cache.mysql.php
+++ b/demos/demo.cache.mysql.php
@@ -2,7 +2,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 //                                                             //

--- a/demos/demo.dirscan.php
+++ b/demos/demo.dirscan.php
@@ -2,7 +2,7 @@
 /////////////////////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>                               //
 //  available at http://getid3.sourceforge.net                                 //
-//            or http://www.getid3.org                                         //
+//            or https://www.getid3.org                                        //
 //          also https://github.com/JamesHeinrich/getID3                       //
 /////////////////////////////////////////////////////////////////////////////////
 ///                                                                            //

--- a/demos/demo.joinmp3.php
+++ b/demos/demo.joinmp3.php
@@ -2,7 +2,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 //                                                             //

--- a/demos/demo.mimeonly.php
+++ b/demos/demo.mimeonly.php
@@ -2,7 +2,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 //                                                             //

--- a/demos/demo.mp3header.php
+++ b/demos/demo.mp3header.php
@@ -1572,7 +1572,7 @@ function MPEGaudioCRCLookup($CRCbit) {
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                ///
-//            or http://www.getid3.org                        ///
+//            or https://www.getid3.org                       ///
 /////////////////////////////////////////////////////////////////
 //                                                             //
 // getid3.mp3.php - part of getID3()                           //

--- a/demos/demo.mysql.php
+++ b/demos/demo.mysql.php
@@ -2,7 +2,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 //                                                             //

--- a/demos/demo.simple.php
+++ b/demos/demo.simple.php
@@ -2,7 +2,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 //                                                             //

--- a/demos/demo.simple.write.php
+++ b/demos/demo.simple.write.php
@@ -2,7 +2,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 //                                                             //

--- a/demos/demo.write.php
+++ b/demos/demo.write.php
@@ -2,7 +2,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 //                                                             //

--- a/demos/demo.zip.php
+++ b/demos/demo.zip.php
@@ -2,7 +2,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 //                                                             //

--- a/demos/index.php
+++ b/demos/index.php
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html><head><title>getID3 demos</title><style type="text/css">BODY, TD, TH { font-family: sans-serif; font-size: 10pt; }</style></head><body>
 
-In this directory are a number of examples of how to use <a href="http://www.getid3.org/">getID3()</a>.<br>
+In this directory are a number of examples of how to use <a href="https://www.getid3.org/">getID3()</a>.<br>
 If you don't know what to run, take a look at <a href="demo.browse.php"><b>demo.browse.php</b></a>
 <hr>
 Other demos:<ul>

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 //                                                             //

--- a/getid3/extension.cache.dbm.php
+++ b/getid3/extension.cache.dbm.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 //                                                             //

--- a/getid3/extension.cache.mysql.php
+++ b/getid3/extension.cache.mysql.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 //                                                             //

--- a/getid3/extension.cache.mysqli.php
+++ b/getid3/extension.cache.mysqli.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 //                                                             //

--- a/getid3/extension.cache.sqlite3.php
+++ b/getid3/extension.cache.sqlite3.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>                               //
 //  available at http://getid3.sourceforge.net                                 //
-//            or http://www.getid3.org                                         //
+//            or https://www.getid3.org                                        //
 //          also https://github.com/JamesHeinrich/getID3                       //
 /////////////////////////////////////////////////////////////////////////////////
 ///                                                                            //

--- a/getid3/getid3.lib.php
+++ b/getid3/getid3.lib.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 //                                                             //

--- a/getid3/getid3.php
+++ b/getid3/getid3.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 //                                                             //
@@ -28,7 +28,7 @@ if (!defined('ENT_SUBSTITUTE')) { // PHP5.3 adds ENT_IGNORE, PHP5.4 adds ENT_SUB
 }
 
 /*
-http://www.getid3.org/phpBB3/viewtopic.php?t=2114
+https://www.getid3.org/phpBB3/viewtopic.php?t=2114
 If you are running into a the problem where filenames with special characters are being handled
 incorrectly by external helper programs (e.g. metaflac), notably with the special characters removed,
 and you are passing in the filename in UTF8 (typically via a HTML form), try uncommenting this line:
@@ -433,7 +433,7 @@ class getID3
 			//$filename = preg_replace('#(?<!gs:)('.preg_quote(DIRECTORY_SEPARATOR).'{2,})#', DIRECTORY_SEPARATOR, $filename);
 
 			// open local file
-			//if (is_readable($filename) && is_file($filename) && ($this->fp = fopen($filename, 'rb'))) { // see http://www.getid3.org/phpBB3/viewtopic.php?t=1720
+			//if (is_readable($filename) && is_file($filename) && ($this->fp = fopen($filename, 'rb'))) { // see https://www.getid3.org/phpBB3/viewtopic.php?t=1720
 			if ((is_readable($filename) || file_exists($filename)) && is_file($filename) && ($this->fp = fopen($filename, 'rb'))) {
 				// great
 			} else {
@@ -1969,7 +1969,7 @@ abstract class getid3_handler
 
 		//return fread($this->getid3->fp, $bytes);
 		/*
-		* http://www.getid3.org/phpBB3/viewtopic.php?t=1930
+		* https://www.getid3.org/phpBB3/viewtopic.php?t=1930
 		* "I found out that the root cause for the problem was how getID3 uses the PHP system function fread().
 		* It seems to assume that fread() would always return as many bytes as were requested.
 		* However, according the PHP manual (http://php.net/manual/en/function.fread.php), this is the case only with regular local files, but not e.g. with Linux pipes.

--- a/getid3/module.archive.gzip.php
+++ b/getid3/module.archive.gzip.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.archive.rar.php
+++ b/getid3/module.archive.rar.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.archive.szip.php
+++ b/getid3/module.archive.szip.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.archive.tar.php
+++ b/getid3/module.archive.tar.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.archive.zip.php
+++ b/getid3/module.archive.zip.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio-video.asf.php
+++ b/getid3/module.audio-video.asf.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio-video.bink.php
+++ b/getid3/module.audio-video.bink.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio-video.flv.php
+++ b/getid3/module.audio-video.flv.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 //                                                             //
 //  FLV module by Seth Kaufman <sethØwhirl-i-gig*com>          //

--- a/getid3/module.audio-video.matroska.php
+++ b/getid3/module.audio-video.matroska.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio-video.mpeg.php
+++ b/getid3/module.audio-video.mpeg.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio-video.nsv.php
+++ b/getid3/module.audio-video.nsv.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio-video.quicktime.php
+++ b/getid3/module.audio-video.quicktime.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //
@@ -223,7 +223,7 @@ class getid3_quicktime extends getid3_handler
 
 		$info = &$this->getid3->info;
 
-		$atom_parent = end($atomHierarchy); // not array_pop($atomHierarchy); see http://www.getid3.org/phpBB3/viewtopic.php?t=1717
+		$atom_parent = end($atomHierarchy); // not array_pop($atomHierarchy); see https://www.getid3.org/phpBB3/viewtopic.php?t=1717
 		array_push($atomHierarchy, $atomname);
 		$atom_structure['hierarchy'] = implode(' ', $atomHierarchy);
 		$atom_structure['name']      = $atomname;
@@ -819,7 +819,7 @@ class getid3_quicktime extends getid3_handler
 											$info['video']['fourcc_lookup'] = $this->QuicktimeVideoCodecLookup($info['video']['fourcc']);
 										}
 
-										// http://www.getid3.org/phpBB3/viewtopic.php?t=1550
+										// https://www.getid3.org/phpBB3/viewtopic.php?t=1550
 										//if ((!empty($atom_structure['sample_description_table'][$i]['width']) && !empty($atom_structure['sample_description_table'][$i]['width'])) && (empty($info['video']['resolution_x']) || empty($info['video']['resolution_y']) || (number_format($info['video']['resolution_x'], 6) != number_format(round($info['video']['resolution_x']), 6)) || (number_format($info['video']['resolution_y'], 6) != number_format(round($info['video']['resolution_y']), 6)))) { // ugly check for floating point numbers
 										if (!empty($atom_structure['sample_description_table'][$i]['width']) && !empty($atom_structure['sample_description_table'][$i]['height'])) {
 											// assume that values stored here are more important than values stored in [tkhd] atom
@@ -1311,7 +1311,7 @@ class getid3_quicktime extends getid3_handler
 					$atom_structure['creation_time_unix']  = getid3_lib::DateMac2Unix($atom_structure['creation_time']);
 					$atom_structure['modify_time_unix']    = getid3_lib::DateMac2Unix($atom_structure['modify_time']);
 
-					// http://www.getid3.org/phpBB3/viewtopic.php?t=1908
+					// https://www.getid3.org/phpBB3/viewtopic.php?t=1908
 					// attempt to compute rotation from matrix values
 					// 2017-Dec-28: uncertain if 90/270 are correctly oriented; values returned by FixedPoint16_16 should perhaps be -1 instead of 65535(?)
 					if (!isset($info['video']['rotate'])) {
@@ -1334,7 +1334,7 @@ class getid3_quicktime extends getid3_handler
 						$info['quicktime']['video']['resolution_x'] = $info['video']['resolution_x'];
 						$info['quicktime']['video']['resolution_y'] = $info['video']['resolution_y'];
 					} else {
-						// see: http://www.getid3.org/phpBB3/viewtopic.php?t=1295
+						// see: https://www.getid3.org/phpBB3/viewtopic.php?t=1295
 						//if (isset($info['video']['resolution_x'])) { unset($info['video']['resolution_x']); }
 						//if (isset($info['video']['resolution_y'])) { unset($info['video']['resolution_y']); }
 						//if (isset($info['quicktime']['video']))    { unset($info['quicktime']['video']);    }
@@ -1529,7 +1529,7 @@ class getid3_quicktime extends getid3_handler
 				case 'code':
 				case 'FIEL': // this is NOT "fiel" (Field Ordering) as describe here: http://developer.apple.com/documentation/QuickTime/QTFF/QTFFChap3/chapter_4_section_2.html
 				case 'tapt': // TrackApertureModeDimensionsAID - http://developer.apple.com/documentation/QuickTime/Reference/QT7-1_Update_Reference/Constants/Constants.html
-							// tapt seems to be used to compute the video size [http://www.getid3.org/phpBB3/viewtopic.php?t=838]
+							// tapt seems to be used to compute the video size [https://www.getid3.org/phpBB3/viewtopic.php?t=838]
 							// * http://lists.apple.com/archives/quicktime-api/2006/Aug/msg00014.html
 							// * http://handbrake.fr/irclogs/handbrake-dev/handbrake-dev20080128_pg2.html
 				case 'ctts'://  STCompositionOffsetAID             - http://developer.apple.com/documentation/QuickTime/Reference/QTRef_Constants/Reference/reference.html
@@ -1783,7 +1783,7 @@ class getid3_quicktime extends getid3_handler
 
 				case 'dscp':
 				case 'rcif':
-					// http://www.getid3.org/phpBB3/viewtopic.php?t=1908
+					// https://www.getid3.org/phpBB3/viewtopic.php?t=1908
 					if (substr($atom_data, 0, 7) == "\x00\x00\x00\x00\x55\xC4".'{') {
 						if ($json_decoded = @json_decode(rtrim(substr($atom_data, 6), "\x00"), true)) {
 							$info['quicktime']['camera'][$atomname] = $json_decoded;
@@ -2695,8 +2695,8 @@ class getid3_quicktime extends getid3_handler
 			$handyatomtranslatorarray['MusicBrainz Disc Id']         = 'MusicBrainz Disc Id';
 
 			// http://age.hobba.nl/audio/tag_frame_reference.html
-			$handyatomtranslatorarray['PLAY_COUNTER']                = 'play_counter'; // Foobar2000 - http://www.getid3.org/phpBB3/viewtopic.php?t=1355
-			$handyatomtranslatorarray['MEDIATYPE']                   = 'mediatype';    // Foobar2000 - http://www.getid3.org/phpBB3/viewtopic.php?t=1355
+			$handyatomtranslatorarray['PLAY_COUNTER']                = 'play_counter'; // Foobar2000 - https://www.getid3.org/phpBB3/viewtopic.php?t=1355
+			$handyatomtranslatorarray['MEDIATYPE']                   = 'mediatype';    // Foobar2000 - https://www.getid3.org/phpBB3/viewtopic.php?t=1355
 			*/
 		}
 		$info = &$this->getid3->info;

--- a/getid3/module.audio-video.real.php
+++ b/getid3/module.audio-video.real.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio-video.riff.php
+++ b/getid3/module.audio-video.riff.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio-video.swf.php
+++ b/getid3/module.audio-video.swf.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio-video.ts.php
+++ b/getid3/module.audio-video.ts.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio.aa.php
+++ b/getid3/module.audio.aa.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio.aac.php
+++ b/getid3/module.audio.aac.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio.ac3.php
+++ b/getid3/module.audio.ac3.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio.amr.php
+++ b/getid3/module.audio.amr.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio.au.php
+++ b/getid3/module.audio.au.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio.avr.php
+++ b/getid3/module.audio.avr.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio.bonk.php
+++ b/getid3/module.audio.bonk.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio.dsf.php
+++ b/getid3/module.audio.dsf.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio.dss.php
+++ b/getid3/module.audio.dss.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio.dts.php
+++ b/getid3/module.audio.dts.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio.flac.php
+++ b/getid3/module.audio.flac.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio.la.php
+++ b/getid3/module.audio.la.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio.lpac.php
+++ b/getid3/module.audio.lpac.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio.midi.php
+++ b/getid3/module.audio.midi.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio.mod.php
+++ b/getid3/module.audio.mod.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio.monkey.php
+++ b/getid3/module.audio.monkey.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio.mp3.php
+++ b/getid3/module.audio.mp3.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio.mpc.php
+++ b/getid3/module.audio.mpc.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio.ogg.php
+++ b/getid3/module.audio.ogg.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio.optimfrog.php
+++ b/getid3/module.audio.optimfrog.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio.rkau.php
+++ b/getid3/module.audio.rkau.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio.shorten.php
+++ b/getid3/module.audio.shorten.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio.tta.php
+++ b/getid3/module.audio.tta.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio.voc.php
+++ b/getid3/module.audio.voc.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio.vqf.php
+++ b/getid3/module.audio.vqf.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.audio.wavpack.php
+++ b/getid3/module.audio.wavpack.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.graphic.bmp.php
+++ b/getid3/module.graphic.bmp.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.graphic.efax.php
+++ b/getid3/module.graphic.efax.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.graphic.gif.php
+++ b/getid3/module.graphic.gif.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.graphic.jpg.php
+++ b/getid3/module.graphic.jpg.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //
@@ -35,7 +35,7 @@ class getid3_jpg extends getid3_handler
 
 		$imageinfo = array();
 		//list($width, $height, $type) = getid3_lib::GetDataImageSize($this->fread($info['filesize']), $imageinfo);
-		list($width, $height, $type) = getimagesize($info['filenamepath'], $imageinfo); // http://www.getid3.org/phpBB3/viewtopic.php?t=1474
+		list($width, $height, $type) = getimagesize($info['filenamepath'], $imageinfo); // https://www.getid3.org/phpBB3/viewtopic.php?t=1474
 
 
 		if (isset($imageinfo['APP13'])) {

--- a/getid3/module.graphic.pcd.php
+++ b/getid3/module.graphic.pcd.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.graphic.png.php
+++ b/getid3/module.graphic.png.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.graphic.svg.php
+++ b/getid3/module.graphic.svg.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.graphic.tiff.php
+++ b/getid3/module.graphic.tiff.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.misc.cue.php
+++ b/getid3/module.misc.cue.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.misc.exe.php
+++ b/getid3/module.misc.exe.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.misc.iso.php
+++ b/getid3/module.misc.iso.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.misc.msoffice.php
+++ b/getid3/module.misc.msoffice.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.misc.par2.php
+++ b/getid3/module.misc.par2.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.misc.pdf.php
+++ b/getid3/module.misc.pdf.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.tag.apetag.php
+++ b/getid3/module.tag.apetag.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.tag.id3v1.php
+++ b/getid3/module.tag.id3v1.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.tag.id3v2.php
+++ b/getid3/module.tag.id3v2.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //
@@ -829,7 +829,7 @@ class getid3_id3v2 extends getid3_handler
 			$parsedFrame['encoding']   = $this->TextEncodingNameLookup($parsedFrame['encodingid']);
 			$parsedFrame['data_raw']   = (string) substr($parsedFrame['data'], $frame_offset);
 
-			// http://www.getid3.org/phpBB3/viewtopic.php?t=1369
+			// https://www.getid3.org/phpBB3/viewtopic.php?t=1369
 			// "this tag typically contains null terminated strings, which are associated in pairs"
 			// "there are users that use the tag incorrectly"
 			$IPLS_parts = array();

--- a/getid3/module.tag.lyrics3.php
+++ b/getid3/module.tag.lyrics3.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/module.tag.xmp.php
+++ b/getid3/module.tag.xmp.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //
@@ -214,7 +214,7 @@ class Image_XMP
 					// Return the XMP text
 					$xmp_data = substr($jpeg_header_data[$i]['SegData'], 29);
 
-					return trim($xmp_data); // trim() should not be neccesary, but some files found in the wild with null-terminated block (known samples from Apple Aperture) causes problems elsewhere (see http://www.getid3.org/phpBB3/viewtopic.php?f=4&t=1153)
+					return trim($xmp_data); // trim() should not be neccesary, but some files found in the wild with null-terminated block (known samples from Apple Aperture) causes problems elsewhere (see https://www.getid3.org/phpBB3/viewtopic.php?f=4&t=1153)
 				}
 			}
 		}

--- a/getid3/write.apetag.php
+++ b/getid3/write.apetag.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/write.id3v1.php
+++ b/getid3/write.id3v1.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/write.id3v2.php
+++ b/getid3/write.id3v2.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //
@@ -2082,7 +2082,7 @@ class getid3_write_id3v2
 			}
 		}
 		// 2016-06-08: relax URL checking to avoid falsely rejecting valid URLs, leave URL validation to the user
-		// http://www.getid3.org/phpBB3/viewtopic.php?t=1926
+		// https://www.getid3.org/phpBB3/viewtopic.php?t=1926
 		return true;
 		/*
 		if ($parts = $this->safe_parse_url($url)) {

--- a/getid3/write.lyrics3.php
+++ b/getid3/write.lyrics3.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/write.metaflac.php
+++ b/getid3/write.metaflac.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/write.php
+++ b/getid3/write.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/write.real.php
+++ b/getid3/write.real.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/getid3/write.vorbiscomment.php
+++ b/getid3/write.vorbiscomment.php
@@ -3,7 +3,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 // See readme.txt for more details                             //

--- a/helperapps/readme.helperapps.txt
+++ b/helperapps/readme.helperapps.txt
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 //                                                             //

--- a/license.txt
+++ b/license.txt
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 
@@ -18,9 +18,9 @@ GNU GPL: https://gnu.org/licenses/gpl.html                   (v3)
 
 GNU LGPL: https://gnu.org/licenses/lgpl.html                 (v3)
 
-Mozilla MPL: http://www.mozilla.org/MPL/2.0/                 (v2)
+Mozilla MPL: https://www.mozilla.org/MPL/2.0/                (v2)
 
-getID3 Commercial License: http://getid3.org/#gCL (payment required)
+getID3 Commercial License: https://www.getid3.org/#gCL (payment required)
 
 *****************************************************************
 *****************************************************************

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 
@@ -18,9 +18,9 @@ GNU GPL: https://gnu.org/licenses/gpl.html                   (v3)
 
 GNU LGPL: https://gnu.org/licenses/lgpl.html                 (v3)
 
-Mozilla MPL: http://www.mozilla.org/MPL/2.0/                 (v2)
+Mozilla MPL: https://www.mozilla.org/MPL/2.0/                (v2)
 
-getID3 Commercial License: http://getid3.org/#gCL (payment required)
+getID3 Commercial License: https://www.getid3.org/#gCL (payment required)
 
 *****************************************************************
 *****************************************************************
@@ -28,10 +28,10 @@ Copies of each of the above licenses are included in the 'licenses'
 directory of the getID3 distribution.
 
 
-       +---------------------------------------------+
-       | If you want to donate, there is a link on   |
-       | http://www.getid3.org for PayPal donations. |
-       +---------------------------------------------+
+       +----------------------------------------------+
+       | If you want to donate, there is a link on    |
+       | https://www.getid3.org for PayPal donations. |
+       +----------------------------------------------+
 
 
 Quick Start
@@ -297,7 +297,7 @@ could essentially write it today with a one-line function:
 
 Future Plans
 ===========================================================================
-http://www.getid3.org/phpBB3/viewforum.php?f=7
+https://www.getid3.org/phpBB3/viewforum.php?f=7
 
 * Better support for MP4 container format
 * Scan for appended ID3v2 tag at end of file per ID3v2.4 specs (Section 5.0)
@@ -339,11 +339,11 @@ http://www.getid3.org/phpBB3/viewforum.php?f=7
 * Optional scan-through-frames for AVI verification
   (thanks rockcohenØmassive-interactive*nl)
 * Support for TTF (thanks infoØbutterflyx*com)
-* Support for DSS (http://www.getid3.org/phpBB3/viewtopic.php?t=171)
+* Support for DSS (https://www.getid3.org/phpBB3/viewtopic.php?t=171)
 * Support for SMAF (http://smaf-yamaha.com/what/demo.html)
-  http://www.getid3.org/phpBB3/viewtopic.php?t=182
-* Support for AMR (http://www.getid3.org/phpBB3/viewtopic.php?t=195)
-* Support for 3gpp (http://www.getid3.org/phpBB3/viewtopic.php?t=195)
+  https://www.getid3.org/phpBB3/viewtopic.php?t=182
+* Support for AMR (https://www.getid3.org/phpBB3/viewtopic.php?t=195)
+* Support for 3gpp (https://www.getid3.org/phpBB3/viewtopic.php?t=195)
 * Support for ID4 (http://www.wackysoft.cjb.net grizlyY2KØhotmail*com)
 * Parse XML data returned in Ogg comments
 * Parse XML data from Quicktime SMIL metafiles (klausrathØmac*com)
@@ -379,7 +379,7 @@ http://www.getid3.org/phpBB3/viewforum.php?f=7
 
 Known Bugs/Issues in getID3() that may be fixed eventually
 ===========================================================================
-http://www.getid3.org/phpBB3/viewtopic.php?t=25
+https://www.getid3.org/phpBB3/viewtopic.php?t=25
 
 * Cannot determine bitrate for MPEG video with VBR video data
   (need documentation)
@@ -405,7 +405,7 @@ http://www.getid3.org/phpBB3/viewtopic.php?t=25
 
 Known Bugs/Issues in getID3() that cannot be fixed
 --------------------------------------------------
-http://www.getid3.org/phpBB3/viewtopic.php?t=25
+https://www.getid3.org/phpBB3/viewtopic.php?t=25
 
 * 32-bit PHP installations only:
   Files larger than 2GB cannot always be parsed fully by getID3()
@@ -435,7 +435,7 @@ http://www.getid3.org/phpBB3/viewtopic.php?t=25
 
 Known Bugs/Issues in other programs
 -----------------------------------
-http://www.getid3.org/phpBB3/viewtopic.php?t=25
+https://www.getid3.org/phpBB3/viewtopic.php?t=25
 
 * MusicBrainz Picard (at least up to v1.3.2) writes multiple
   ID3v2.3 genres in non-standard forward-slash separated text

--- a/structure.txt
+++ b/structure.txt
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////
 /// getID3() by James Heinrich <info@getid3.org>               //
 //  available at http://getid3.sourceforge.net                 //
-//            or http://www.getid3.org                         //
+//            or https://www.getid3.org                        //
 //          also https://github.com/JamesHeinrich/getID3       //
 /////////////////////////////////////////////////////////////////
 //                                                             //


### PR DESCRIPTION
- Added `branch-alias` for more correct definition of the 1.9.x dev-branch in Composer.
- Also I replaced all links from http://www.getid3.org/ to https://www.getid3.org/ because the website automatically does a redirect.