### PR TITLE
Add some standard .gitattribute entries

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -31,3 +31,4 @@ composer.json export-ignore
 phpunit.xml.dist export-ignore
 build/ export-ignore
 tests/ export-ignore
+phpstan.neon export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -20,3 +20,14 @@
 *.PDF	 diff=astextplain
 *.rtf	 diff=astextplain
 *.RTF	 diff=astextplain
+
+.editorconfig export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+Doxyfile export-ignore
+composer.json export-ignore
+.phpcs.xml export-ignore
+phpunit.xml.dist export-ignore
+build/ export-ignore
+tests/ export-ignore


### PR DESCRIPTION
Stops these files being exported when installing via composer