### PR TITLE
add support for DS2 v. 8

### DIFF
--- a/getid3/getid3.php
+++ b/getid3/getid3.php
@@ -834,7 +834,7 @@ class getID3
 
 				// DSS  - audio       - Digital Speech Standard
 				'dss'  => array(
-							'pattern'   => '^[\\x02-\\x06]ds[s2]',
+							'pattern'   => '^[\\x02-\\x08]ds[s2]',
 							'group'     => 'audio',
 							'module'    => 'dss',
 							'mime_type' => 'application/octet-stream',

--- a/getid3/module.audio.dss.php
+++ b/getid3/module.audio.dss.php
@@ -26,8 +26,8 @@ class getid3_dss extends getid3_handler
 		$this->fseek($info['avdataoffset']);
 		$DSSheader  = $this->fread(1540);
 
-		if (!preg_match('#^[\\x02-\\x06]ds[s2]#', $DSSheader)) {
-			$this->error('Expecting "[02-06] 64 73 [73|32]" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes(substr($DSSheader, 0, 4)).'"');
+		if (!preg_match('#^[\\x02-\\x08]ds[s2]#', $DSSheader)) {
+			$this->error('Expecting "[02-08] 64 73 [73|32]" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes(substr($DSSheader, 0, 4)).'"');
 			return false;
 		}
 


### PR DESCRIPTION
I have noticed DS2 files coming to my system that have 08 in version field (first byte). As far as I am able to tell, this new version doesn't change anything significant in file header (at least nothing that getID3 reads and tries to interpret), and the results of analyze() are ok.
If you feel it's worth adding, please accept this pull request.