### PR TITLE
Fix issue #191 Unsupported operand types module.audio.ac3.php:763

### DIFF
--- a/getid3/module.audio.ac3.php
+++ b/getid3/module.audio.ac3.php
@@ -760,7 +760,11 @@ class getid3_ac3 extends getid3_handler
 		}
 		if (($fscod == 1) && $padding) {
 			// frame lengths are padded by 1 word (16 bits) at 44100
-			$frameSizeLookup[$frmsizecod] += 2;
+			if (is_array($frameSizeLookup[$frmsizecod])) {
+				$frameSizeLookup[$frmsizecod][0] += 2;
+			}else{
+				$framesizeidmeSizeLookup[$frmsizecod] += 2;
+			}
 		}
 		return (isset($frameSizeLookup[$framesizeid][$fscod]) ? $frameSizeLookup[$framesizeid][$fscod] : false);
 	}


### PR DESCRIPTION
Fix to issue #191 PHP Fatal error:  Uncaught Error: Unsupported operand types in /var/www/getID3/getid3/module.audio.ac3.php:763