### PR TITLE
Bugfix/copy tags to comments optional entities

### DIFF
--- a/demos/demo.basic.php
+++ b/demos/demo.basic.php
@@ -28,7 +28,7 @@ $ThisFileInfo = $getID3->analyze($filename);
  metadata is all available in one location for all tag formats
  metainformation is always available under [tags] even if this is not called
 */
-getid3_lib::CopyTagsToComments($ThisFileInfo);
+$getID3->CopyTagsToComments($ThisFileInfo);
 
 /*
  Output desired information in whatever format you want

--- a/demos/demo.browse.php
+++ b/demos/demo.browse.php
@@ -99,7 +99,7 @@ if (isset($_REQUEST['filename'])) {
 	}
 
 
-	getid3_lib::CopyTagsToComments($ThisFileInfo);
+	$getID3->CopyTagsToComments($ThisFileInfo);
 
 	$listdirectory = dirname($_REQUEST['filename']);
 	$listdirectory = realpath($listdirectory); // get rid of /../../ references
@@ -179,7 +179,7 @@ if (isset($_REQUEST['filename'])) {
 				$getID3->setOption(array('option_md5_data' => (isset($_REQUEST['ShowMD5']) && GETID3_DEMO_BROWSE_ALLOW_MD5_LINK)));
 				$fileinformation = $getID3->analyze($currentfilename);
 
-				getid3_lib::CopyTagsToComments($fileinformation);
+				$getID3->CopyTagsToComments($fileinformation);
 
 				$TotalScannedFilesize += (isset($fileinformation['filesize']) ? $fileinformation['filesize'] : 0);
 

--- a/demos/demo.mysql.php
+++ b/demos/demo.mysql.php
@@ -290,7 +290,7 @@ function SynchronizeAllTags($filename, $synchronizefrom='all', $synchronizeto='A
 	set_time_limit(30);
 
 	$ThisFileInfo = $getID3->analyze($filename);
-	getid3_lib::CopyTagsToComments($ThisFileInfo);
+	$getID3->CopyTagsToComments($ThisFileInfo);
 
 	if ($synchronizefrom == 'all') {
 		$SourceArray = (!empty($ThisFileInfo['comments']) ? $ThisFileInfo['comments'] : array());
@@ -458,7 +458,7 @@ if (!empty($_REQUEST['scan']) || !empty($_REQUEST['newscan']) || !empty($_REQUES
 		echo '<br>'.date('H:i:s').' ['.number_format(++$rowcounter).' / '.number_format($totaltoprocess).'] '.str_replace('\\', '/', $filename);
 
 		$ThisFileInfo = $getID3->analyze($filename);
-		getid3_lib::CopyTagsToComments($ThisFileInfo);
+		$getID3->CopyTagsToComments($ThisFileInfo);
 
 		if (file_exists($filename)) {
 			$ThisFileInfo['file_modified_time'] = filemtime($filename);
@@ -1774,7 +1774,7 @@ if (!empty($_REQUEST['scan']) || !empty($_REQUEST['newscan']) || !empty($_REQUES
 		while ($row = mysql_fetch_array($result)) {
 			set_time_limit(30);
 			$ThisFileInfo = $getID3->analyze($filename);
-			getid3_lib::CopyTagsToComments($ThisFileInfo);
+			$getID3->CopyTagsToComments($ThisFileInfo);
 
 			if (!empty($ThisFileInfo['tags'])) {
 

--- a/demos/demo.simple.php
+++ b/demos/demo.simple.php
@@ -37,7 +37,7 @@ while (($file = readdir($dir)) !== false) {
 
 		$ThisFileInfo = $getID3->analyze($FullFileName);
 
-		getid3_lib::CopyTagsToComments($ThisFileInfo);
+		$getID3->CopyTagsToComments($ThisFileInfo);
 
 		// output desired information in whatever format you want
 		echo '<tr>';

--- a/getid3/getid3.lib.php
+++ b/getid3/getid3.lib.php
@@ -1529,10 +1529,11 @@ class getid3_lib
 
 	/**
 	 * @param array $ThisFileInfo
+	 * @param bool  $option_tags_html default true (just as in the main getID3 class)
 	 *
 	 * @return bool
 	 */
-	public static function CopyTagsToComments(&$ThisFileInfo) {
+	public static function CopyTagsToComments(&$ThisFileInfo, $option_tags_html=true) {
 
 		// Copy all entries from ['tags'] into common ['comments']
 		if (!empty($ThisFileInfo['tags'])) {
@@ -1597,19 +1598,21 @@ class getid3_lib
 				}
 			}
 
-			// Copy to ['comments_html']
-			if (!empty($ThisFileInfo['comments'])) {
-				foreach ($ThisFileInfo['comments'] as $field => $values) {
-					if ($field == 'picture') {
-						// pictures can take up a lot of space, and we don't need multiple copies of them
-						// let there be a single copy in [comments][picture], and not elsewhere
-						continue;
-					}
-					foreach ($values as $index => $value) {
-						if (is_array($value)) {
-							$ThisFileInfo['comments_html'][$field][$index] = $value;
-						} else {
-							$ThisFileInfo['comments_html'][$field][$index] = str_replace('&#0;', '', self::MultiByteCharString2HTML($value, $ThisFileInfo['encoding']));
+			if ($option_tags_html) {
+				// Copy to ['comments_html']
+				if (!empty($ThisFileInfo['comments'])) {
+					foreach ($ThisFileInfo['comments'] as $field => $values) {
+						if ($field == 'picture') {
+							// pictures can take up a lot of space, and we don't need multiple copies of them
+							// let there be a single copy in [comments][picture], and not elsewhere
+							continue;
+						}
+						foreach ($values as $index => $value) {
+							if (is_array($value)) {
+								$ThisFileInfo['comments_html'][$field][$index] = $value;
+							} else {
+								$ThisFileInfo['comments_html'][$field][$index] = str_replace('&#0;', '', self::MultiByteCharString2HTML($value, $ThisFileInfo['encoding']));
+							}
 						}
 					}
 				}

--- a/getid3/getid3.php
+++ b/getid3/getid3.php
@@ -1526,6 +1526,17 @@ class getID3
 	}
 
 	/**
+	 * Calls getid3_lib::CopyTagsToComments() but passes in the option_tags_html setting from this instance of getID3
+	 *
+	 * @param array $ThisFileInfo
+	 *
+	 * @return bool
+	 */
+	public function CopyTagsToComments(&$ThisFileInfo) {
+	    return getid3_lib::CopyTagsToComments($ThisFileInfo, $this->option_tags_html);
+	}
+
+	/**
 	 * @param string $algorithm
 	 *
 	 * @return array|bool


### PR DESCRIPTION
`getid3_lib::CopyTagsToComments($info)` spends time creating HTML versions of tags, even if the instance of getID3 that created the `$info` array had the option `option_tags_html` set to false.

This changeset adds an optional `$option_tags_html` (defaulting to true) to `getid3_lib::CopyTagsToComments()`, and then an instance method `$getID3->CopyTagsToComments()` which passes the option in as it was originally set.

The demo files are also updated to match, although the change should be fully backward compatible.