### PR TITLE
When parsing Quicktime subatoms, check the data length against...

### DIFF
--- a/getid3/module.audio-video.quicktime.php
+++ b/getid3/module.audio-video.quicktime.php
@@ -2020,6 +2020,12 @@ class getid3_quicktime extends getid3_handler
 				}
 				return $atom_structure;
 			}
+			if (strlen($subatomdata) < $subatomsize-8) {
+			    // we don't have enough data to decode the subatom.
+			    // this may be because we are refusing to parse large subatoms, or it may be because this atom had its size set too large
+			    // so we passed in the start of a following atom incorrectly?
+			    return $atom_structure;
+			}
 			$atom_structure[$subatomcounter++] = $this->QuicktimeParseAtom($subatomname, $subatomsize, $subatomdata, $baseoffset + $subatomoffset, $atomHierarchy, $ParseAllPossibleAtoms);
 			$subatomoffset += $subatomsize;
 		}


### PR DESCRIPTION
...the expected length.

Sometimes a container will contain slightly more data than expected, enough to read the header of an atom which is actually outside of the container. This guards against that. (The atom will be correctly read as parallel to the container in the next pass).

Example: a 'moov' atom with the first 8 bytes of a subsequent 'uuid' atom that appears afterward.

Addresses #226