### PR TITLE
Travis: start testing against PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,11 @@ matrix:
     - php: 7.3
       env: PHPSTAN=1
     - php: 7.4
+    - php: nightly
+
+  allow_failures:
+    # Allow failures for unstable builds.
+    - php: "nightly"
 
 before_script:
   - travis_retry composer install --prefer-source --quiet --no-interaction


### PR DESCRIPTION
The build against PHP 8 will currently fail, but that is addressed in another PR #256.