### PR TITLE
PHP 8.0: required parameters are no longer allowed after optional parameters

### DIFF
--- a/demos/demo.mysqli.php
+++ b/demos/demo.mysqli.php
@@ -289,7 +289,7 @@ if (isset($ExistingTableFields['comments_all']) && ($ExistingTableFields['commen
 }
 
 
-function SynchronizeAllTags($filename, $synchronizefrom='all', $synchronizeto='A12', &$errors) {
+function SynchronizeAllTags($filename, $synchronizefrom='all', $synchronizeto='A12', &$errors = array()) {
 	global $getID3;
 
 	set_time_limit(30);


### PR DESCRIPTION
By giving the `&$errors` parameter a default value, this issue is circumvented without breaking backward-compatibility.