### PR TITLE
PHP 8.0: only call libxml_disable_entity_loader() in PHP < 8

### DIFF
--- a/getid3/getid3.lib.php
+++ b/getid3/getid3.lib.php
@@ -720,12 +720,18 @@ class getid3_lib
 	 */
 	public static function XML2array($XMLstring) {
 		if (function_exists('simplexml_load_string') && function_exists('libxml_disable_entity_loader')) {
-			// http://websec.io/2012/08/27/Preventing-XEE-in-PHP.html
-			// https://core.trac.wordpress.org/changeset/29378
-			$loader = libxml_disable_entity_loader(true);
+			if (PHP_VERSION_ID < 80000) {
+				// http://websec.io/2012/08/27/Preventing-XEE-in-PHP.html
+				// https://core.trac.wordpress.org/changeset/29378
+				// This function has been deprecated in PHP 8.0 because in libxml 2.9.0, external entity loading is
+				// disabled by default, so this function is no longer needed to protect against XXE attacks.
+				$loader = libxml_disable_entity_loader(true);
+			}
 			$XMLobject = simplexml_load_string($XMLstring, 'SimpleXMLElement', LIBXML_NOENT);
 			$return = self::SimpleXMLelement2array($XMLobject);
-			libxml_disable_entity_loader($loader);
+			if (PHP_VERSION_ID < 80000) {
+				libxml_disable_entity_loader($loader);
+			}
 			return $return;
 		}
 		return false;


### PR DESCRIPTION
As per the PHP 8.0 changelog:

> `libxml_disable_entity_loader()` has been deprecated. As libxml 2.9.0 is now
> required, external entity loading is guaranteed to be disabled by default,
> and this function is no longer needed to protect against XXE attacks.

Source: https://github.com/php/php-src/blob/71bfa5344ab207072f4cd25745d7023096338385/UPGRADING#L808-L811

Calling the function conditionally will prevent deprecation warnings being thrown.