### PR TITLE
fixed possible endless loop processing png file with wrong filesize

### DIFF
--- a/getid3/module.graphic.png.php
+++ b/getid3/module.graphic.png.php
@@ -66,7 +66,13 @@ class getid3_png extends getid3_handler
 			$truncated_data = false;
 			while (((strlen($PNGfiledata) - $offset) < ($chunk['data_length'] + 4)) && ($this->ftell() < $info['filesize'])) {
 				if (strlen($PNGfiledata) < $this->max_data_bytes) {
-					$PNGfiledata .= $this->fread($this->getid3->fread_buffer_size());
+					$str = $this->fread($this->getid3->fread_buffer_size());
+					if (strlen($str) > 0) {
+						$PNGfiledata .= $str;
+					} else {
+						$this->warning('At offset '.$offset.' chunk "'.substr($PNGfiledata, $offset, 4).'" no more data to read, data chunk will be truncated at '.(strlen($PNGfiledata) - 8).' bytes');
+						break;
+					}
 				} else {
 					$this->warning('At offset '.$offset.' chunk "'.substr($PNGfiledata, $offset, 4).'" exceeded max_data_bytes value of '.$this->max_data_bytes.', data chunk will be truncated at '.(strlen($PNGfiledata) - 8).' bytes');
 					break;


### PR DESCRIPTION
I'm processing a list of files that I read from an external url and saving them with the same filename on disk (temp name only for processing). Since the library is using `filesize` which is cached, the png parser goes into an endless loop when dealing with a smaller file than the previous one.

I have few options to solve it outside the library like using a different name per file or calling `clearstatcache` before every call to the library, but I still think it should not be possible to reach an endless loop in the code.

Below is an example code that should trigger the endless loop. _big-file.png_ should be bigger in size than _small-file.png_. 

My fix checks that `fread` returns data and breaks with a warning if it returns empty.

```
<?php
        $target = '/tmp/tmp.png';

        // don't use PHP copy because it will clear cache
        $src = '/tmp/big-file.png';
        exec("cp $src $target");
        $getID3 = new \getID3;
        $analyze = $getID3->analyze($target);

        $src = '/tmp/small-file.png';
        exec("cp $src $target");
        $getID3 = new \getID3;
        $analyze = $getID3->analyze($target);
```



