### PR TITLE
Fix "Trying to access array offset on value of type int" error on php7.4+

### DIFF
--- a/getid3/write.php
+++ b/getid3/write.php
@@ -670,7 +670,7 @@ class getid3_writetags
 									do {
 										// if UTF-8 string does not include any characters above chr(127) then it is identical to ISO-8859-1
 										for ($i = 0; $i < strlen($value); $i++) {
-											if (ord($value[$i]) > 127) {
+											if (!is_int($value) && ord($value[$i]) > 127) {
 												break 2;
 											}
 										}


### PR DESCRIPTION
The "track number" tag of mp3 files is usually an int. Accessing an int with an array offset works in php7.3 and older, but breaks in php7.4: https://3v4l.org/MQ9gK

