### PR TITLE
Fix MP3 CBR detection for non LAME "Info" frames.

### DIFF
--- a/getid3/module.audio.mp3.php
+++ b/getid3/module.audio.mp3.php
@@ -672,35 +672,6 @@ class getid3_mp3 extends getid3_handler
 				if ($thisfile_mpeg_audio['xing_flags']['bytes']) {
 					$thisfile_mpeg_audio['VBR_bytes']  = getid3_lib::BigEndian2Int(substr($headerstring, $VBRidOffset + 12, 4));
 				}
-
-				//if (($thisfile_mpeg_audio['bitrate'] == 'free') && !empty($thisfile_mpeg_audio['VBR_frames']) && !empty($thisfile_mpeg_audio['VBR_bytes'])) {
-				//if (!empty($thisfile_mpeg_audio['VBR_frames']) && !empty($thisfile_mpeg_audio['VBR_bytes'])) {
-				if (!empty($thisfile_mpeg_audio['VBR_frames'])) {
-					$used_filesize  = 0;
-					if (!empty($thisfile_mpeg_audio['VBR_bytes'])) {
-						$used_filesize = $thisfile_mpeg_audio['VBR_bytes'];
-					} elseif (!empty($info['filesize'])) {
-						$used_filesize  = $info['filesize'];
-						$used_filesize -= (isset($info['id3v2']['headerlength']) ? intval($info['id3v2']['headerlength']) : 0);
-						$used_filesize -= (isset($info['id3v1']) ? 128 : 0);
-						$used_filesize -= (isset($info['tag_offset_end']) ? $info['tag_offset_end'] - $info['tag_offset_start'] : 0);
-						$this->warning('MP3.Xing header missing VBR_bytes, assuming MPEG audio portion of file is '.number_format($used_filesize).' bytes');
-					}
-
-					$framelengthfloat = $used_filesize / $thisfile_mpeg_audio['VBR_frames'];
-
-					if ($thisfile_mpeg_audio['layer'] == '1') {
-						// BitRate = (((FrameLengthInBytes / 4) - Padding) * SampleRate) / 12
-						//$info['audio']['bitrate'] = ((($framelengthfloat / 4) - intval($thisfile_mpeg_audio['padding'])) * $thisfile_mpeg_audio['sample_rate']) / 12;
-						$info['audio']['bitrate'] = ($framelengthfloat / 4) * $thisfile_mpeg_audio['sample_rate'] * (2 / $info['audio']['channels']) / 12;
-					} else {
-						// Bitrate = ((FrameLengthInBytes - Padding) * SampleRate) / 144
-						//$info['audio']['bitrate'] = (($framelengthfloat - intval($thisfile_mpeg_audio['padding'])) * $thisfile_mpeg_audio['sample_rate']) / 144;
-						$info['audio']['bitrate'] = $framelengthfloat * $thisfile_mpeg_audio['sample_rate'] * (2 / $info['audio']['channels']) / 144;
-					}
-					$thisfile_mpeg_audio['framelength'] = floor($framelengthfloat);
-				}
-
 				if ($thisfile_mpeg_audio['xing_flags']['toc']) {
 					$LAMEtocData = substr($headerstring, $VBRidOffset + 16, 100);
 					for ($i = 0; $i < 100; $i++) {
@@ -1003,6 +974,7 @@ class getid3_mp3 extends getid3_handler
 					if ($thisfile_mpeg_audio['VBR_bitrate'] > 0) {
 						$info['audio']['bitrate']       = $thisfile_mpeg_audio['VBR_bitrate'];
 						$thisfile_mpeg_audio['bitrate'] = $thisfile_mpeg_audio['VBR_bitrate']; // to avoid confusion
+						$thisfile_mpeg_audio['framelength'] = floor($thisfile_mpeg_audio['VBR_bytes'] / $thisfile_mpeg_audio['VBR_frames']);
 					}
 					break;
 			}

--- a/getid3/module.audio.mp3.php
+++ b/getid3/module.audio.mp3.php
@@ -903,17 +903,24 @@ class getid3_mp3 extends getid3_handler
 
 						// LAME CBR
 						if ($thisfile_mpeg_audio_lame_raw['vbr_method'] == 1) {
-
 							$thisfile_mpeg_audio['bitrate_mode'] = 'cbr';
-							$thisfile_mpeg_audio['bitrate'] = self::ClosestStandardMP3Bitrate($thisfile_mpeg_audio['bitrate']);
-							$info['audio']['bitrate'] = $thisfile_mpeg_audio['bitrate'];
-							//if (empty($thisfile_mpeg_audio['bitrate']) || (!empty($thisfile_mpeg_audio_lame['bitrate_min']) && ($thisfile_mpeg_audio_lame['bitrate_min'] != 255))) {
-							//	$thisfile_mpeg_audio['bitrate'] = $thisfile_mpeg_audio_lame['bitrate_min'];
-							//}
-
 						}
 
 					}
+
+				} else {
+
+					// not LAME (such as Lavf/libavformat)
+					if (substr($headerstring, $VBRidOffset, strlen('Info')) == 'Info') {
+						$thisfile_mpeg_audio['bitrate_mode'] = 'cbr';
+					}
+
+				}
+
+				if ($thisfile_mpeg_audio['bitrate_mode'] == 'cbr') {
+					// restart decode after VBR info frame, the audio data in the info frame may not match the actual audio frames
+					$offset += $thisfile_mpeg_audio['framelength'];
+					return $this->decodeMPEGaudioHeader($offset, $info, $recursivesearch, $ScanAsCBR, $FastMPEGheaderScan);
 				}
 
 			} else {


### PR DESCRIPTION
This is a potential fix for #287.

The commit logs go into some detail on my analysis of the issue. I am not familiar enough with the existing code base (or mp3 format in general) to know if this is a good fix or what else I may have broke. It should be a useful reference for the issue anyway.

One limitation of the fix (or maybe this limitation always existed in some form) is for how it handles bad data. For example the ffmpeg_64k_cbr_corrupt.mp3 file will generate the following warning:
>Unknown data before synch (ID3v2 header ends at 45, then 390 bytes garbage, synch detected at 435)

But in actual fact not all of that 390 bytes is garbage, part of that is the valid "Info" frame.

This PR also includes a second commit that is only loosely related to the issue but is something I came across while debugging it.

If any of this looks close to usable I am happy to make further refinements based on feedback or drop the second commit from the PR entirely.
