### PR TITLE
Don't crash when an invalid TIFF file has no fields.

### DIFF
--- a/getid3/module.graphic.tiff.php
+++ b/getid3/module.graphic.tiff.php
@@ -125,6 +125,10 @@ class getid3_tiff extends getid3_handler
 		}
 
 		foreach ($info['tiff']['ifd'] as $IFDid => $IFDarray) {
+			if(!isset($IFDarray['fields'])) {
+				continue;
+			}
+
 			foreach ($IFDarray['fields'] as $key => $fieldarray) {
 				switch ($fieldarray['raw']['tag']) {
 					case 256: // ImageWidth


### PR DESCRIPTION
getID3 sometimes detects files as TIFF incorrectly, and then extracts no fields, causing a crash.

(The file was a minimal example from https://stackoverflow.com/questions/57192090/minimal-audio-wav-or-mp3-file-in-bytes-for-unit-testing, and may not actually be a valid MP3 after all, but that isn't really important for the purpose of the fix).