### PR TITLE
Allow detecting ID3v1 on minimal example files.

### DIFF
--- a/getid3/module.tag.id3v1.php
+++ b/getid3/module.tag.id3v1.php
@@ -31,9 +31,16 @@ class getid3_id3v1 extends getid3_handler
 			return false;
 		}
 
-		$this->fseek(-256, SEEK_END);
-		$preid3v1 = $this->fread(128);
-		$id3v1tag = $this->fread(128);
+		if($info['filesize'] < 256) {
+			$this->fseek(-128, SEEK_END);
+			$preid3v1 = '';
+			$id3v1tag = $this->fread(128);
+		} else {
+			$this->fseek(-256, SEEK_END);
+			$preid3v1 = $this->fread(128);
+			$id3v1tag = $this->fread(128);
+		}
+
 
 		if (substr($id3v1tag, 0, 3) == 'TAG') {
 


### PR DESCRIPTION
The smallest example file is only 200 bytes. File attached
[id3v1_artist_album_title.mp3.zip](https://github.com/JamesHeinrich/getID3/files/6018592/id3v1_artist_album_title.mp3.zip)
