### PR TITLE
Fix DivisionByZeroError on QuickTime files with no playable content

### DIFF
--- a/getid3/module.audio-video.quicktime.php
+++ b/getid3/module.audio-video.quicktime.php
@@ -169,7 +169,7 @@ class getid3_quicktime extends getid3_handler
 			}
 		}
 
-		if (!isset($info['bitrate']) && isset($info['playtime_seconds'])) {
+		if (!isset($info['bitrate']) && isset($info['playtime_seconds']) && $info['playtime_seconds'] > 0) {
 			$info['bitrate'] = (($info['avdataend'] - $info['avdataoffset']) * 8) / $info['playtime_seconds'];
 		}
 		if (isset($info['bitrate']) && !isset($info['audio']['bitrate']) && !isset($info['quicktime']['video'])) {


### PR DESCRIPTION
Another fix for minimal files (as used in my test cases) - empty.mp4 is from https://github.com/mathiasbynens/small, and the tagged one was tagged with AtomicParsley

https://user-images.githubusercontent.com/75862/109072012-5e37b280-76ec-11eb-9954-b48b15bc816b.mp4


https://user-images.githubusercontent.com/75862/109072018-5ed04900-76ec-11eb-99cf-79c1b1ee5ede.mp4

