### PR TITLE
Replace IMG_JPG with IMAGETYPE_JPEG because it does not require GD

### DIFF
--- a/getid3/getid3.php
+++ b/getid3/getid3.php
@@ -17,10 +17,6 @@ if (!defined('GETID3_OS_ISWINDOWS')) {
 if (!defined('GETID3_INCLUDEPATH')) {
 	define('GETID3_INCLUDEPATH', dirname(__FILE__).DIRECTORY_SEPARATOR);
 }
-// Workaround Bug #39923 (https://bugs.php.net/bug.php?id=39923)
-if (!defined('IMG_JPG') && defined('IMAGETYPE_JPEG')) {
-	define('IMG_JPG', IMAGETYPE_JPEG);
-}
 if (!defined('ENT_SUBSTITUTE')) { // PHP5.3 adds ENT_IGNORE, PHP5.4 adds ENT_SUBSTITUTE
 	define('ENT_SUBSTITUTE', (defined('ENT_IGNORE') ? ENT_IGNORE : 8));
 }

--- a/getid3/module.graphic.jpg.php
+++ b/getid3/module.graphic.jpg.php
@@ -62,7 +62,7 @@ class getid3_jpg extends getid3_handler
 
 		$returnOK = false;
 		switch ($type) {
-			case IMG_JPG:
+			case IMAGETYPE_JPEG:
 				$info['video']['resolution_x'] = $width;
 				$info['video']['resolution_y'] = $height;
 


### PR DESCRIPTION
According to the documentation of [`getimagesize`](https://www.php.net/manual/en/function.getimagesize.php):
> Index 2 is one of the [IMAGETYPE_XXX](https://www.php.net/manual/en/image.constants.php) constants indicating the type of the image.

IMAGETYPE_JPEG comes from the standard library, while IMG_JPG requires the `gd` extension to be installed.

Example: https://3v4l.org/4PpTD

Closes #293