### PR TITLE
PHP 8.0: silence a deprecation warning instead of not calling the function

### DIFF
--- a/getid3/getid3.lib.php
+++ b/getid3/getid3.lib.php
@@ -720,18 +720,14 @@ class getid3_lib
 	 */
 	public static function XML2array($XMLstring) {
 		if (function_exists('simplexml_load_string') && function_exists('libxml_disable_entity_loader')) {
-			if (PHP_VERSION_ID < 80000) {
-				// http://websec.io/2012/08/27/Preventing-XEE-in-PHP.html
-				// https://core.trac.wordpress.org/changeset/29378
-				// This function has been deprecated in PHP 8.0 because in libxml 2.9.0, external entity loading is
-				// disabled by default, so this function is no longer needed to protect against XXE attacks.
-				$loader = libxml_disable_entity_loader(true);
-			}
+			// http://websec.io/2012/08/27/Preventing-XEE-in-PHP.html
+			// https://core.trac.wordpress.org/changeset/29378
+			// This function has been deprecated in PHP 8.0 because in libxml 2.9.0, external entity loading is
+			// disabled by default, but is still needed when LIBXML_NOENT is used.
+			$loader = @libxml_disable_entity_loader(true);
 			$XMLobject = simplexml_load_string($XMLstring, 'SimpleXMLElement', LIBXML_NOENT);
 			$return = self::SimpleXMLelement2array($XMLobject);
-			if (PHP_VERSION_ID < 80000 && isset($loader)) {
-				libxml_disable_entity_loader($loader);
-			}
+			@libxml_disable_entity_loader($loader);
 			return $return;
 		}
 		return false;


### PR DESCRIPTION
As discussed via email.

This patch should work for the time being (until PHP 9 is released a few years from now), though it would be infinitely better to refactor the code to use the [libxml_set_external_entity_loader()](https://www.php.net/manual/en/function.libxml-set-external-entity-loader.php) function instead. Unfortunately, I don't feel I have enough of the domain specific knowledge needed to be in a good place to create that particular patch, so I will need to leave that future iteration to you or others in the GetID3 team.