### PR TITLE
Use predefined INF/NAN constants instead of float/string

### DIFF
--- a/getid3/getid3.lib.php
+++ b/getid3/getid3.lib.php
@@ -242,7 +242,7 @@ class getid3_lib
 	/**
 	 * ANSI/IEEE Standard 754-1985, Standard for Binary Floating Point Arithmetic
 	 *
-	 * @link http://www.psc.edu/general/software/packages/ieee/ieee.html
+	 * @link https://web.archive.org/web/20120325162206/http://www.psc.edu/general/software/packages/ieee/ieee.php
 	 * @link http://www.scri.fsu.edu/~jac/MAD3401/Backgrnd/ieee.html
 	 *
 	 * @param string $byteword
@@ -294,12 +294,12 @@ class getid3_lib
 
 		if (($exponent == (pow(2, $exponentbits) - 1)) && ($fraction != 0)) {
 			// Not a Number
-			$floatvalue = false;
+			$floatvalue = NAN;
 		} elseif (($exponent == (pow(2, $exponentbits) - 1)) && ($fraction == 0)) {
 			if ($signbit == '1') {
-				$floatvalue = '-infinity';
+				$floatvalue = -INF;
 			} else {
-				$floatvalue = '+infinity';
+				$floatvalue = INF;
 			}
 		} elseif (($exponent == 0) && ($fraction == 0)) {
 			if ($signbit == '1') {


### PR DESCRIPTION
We have an incomprehensible state when, when calculating in `BigEndian2Float` and a string of `INF`/`NAN` was passed as a value. In that case we returned `(bool) false` for `NAN` values and `(string) '+infinity'`/`(string) '-infinity'` for infinity. And at the end of the execution of this method these values were cased to float.
In some PHP versions, the expression `(float) '-infinity'` even worked! See https://3v4l.org/14nSQ
But this was recognized as a bug and was fixed by [this commit](https://github.com/php/php-src/commit/9f2ab75b1096b881ee97eb2b436763aa14c19635).

Therefore, just use the predefined constants `INF` and `NAN`, which are still float, but when converted to a string, they will be output as `(string) 'INF'` or `(string) 'NAN'`. And also we can use `is_nan()`/`is_infinite()` on these values.