### PR TITLE
Replace preg_match to strpos() while defining a temporary directory 

### DIFF
--- a/getid3/getid3.php
+++ b/getid3/getid3.php
@@ -53,7 +53,7 @@ if ($open_basedir) {
 		if (substr($basedir, -1, 1) != DIRECTORY_SEPARATOR) {
 			$basedir .= DIRECTORY_SEPARATOR;
 		}
-		if (preg_match('#^'.preg_quote($basedir).'#', $temp_dir)) {
+		if (strpos($temp_dir, $basedir) === 0) {
 			$found_valid_tempdir = true;
 			break;
 		}


### PR DESCRIPTION
Check that the path to the temporary directory is in the open_basedir list using `strpos` instead of a regular expression
This also fixes the problem with rarely used paths like "/foo/bar#baz:/tmp", since # character is not escaped by preg_quote until PHP 7.3 (https://bugs.php.net/bug.php?id=75355). Sample: https://3v4l.org/N0h1f