### PR TITLE
Update QuicktimeContentRatingLookup() to utilize the newer 'rtng' explicit value

### DIFF
--- a/getid3/module.audio-video.quicktime.php
+++ b/getid3/module.audio-video.quicktime.php
@@ -2606,8 +2606,9 @@ $this->warning('incomplete/incorrect handling of "stsd" with Parrot metadata in 
 		static $QuicktimeContentRatingLookup = array();
 		if (empty($QuicktimeContentRatingLookup)) {
 			$QuicktimeContentRatingLookup[0]  = 'None';
+			$QuicktimeContentRatingLookup[1]  = 'Explicit';
 			$QuicktimeContentRatingLookup[2]  = 'Clean';
-			$QuicktimeContentRatingLookup[4]  = 'Explicit';
+			$QuicktimeContentRatingLookup[4]  = 'Explicit (old)';
 		}
 		return (isset($QuicktimeContentRatingLookup[$rtng]) ? $QuicktimeContentRatingLookup[$rtng] : 'invalid');
 	}


### PR DESCRIPTION
Per [here](https://exiftool.org/TagNames/QuickTime.html) (and from experience), the explicit value for the 'rtng' tag (a.k.a. "ITUNESADVISORY" in many tag editors) is indicated by a value of 1. Previously it was indicated by a 4, so I chose to keep them both.