### PR TITLE
PHP 8.1: getid3_lib::mb_basename(): fix deprecation notice

### DIFF
--- a/getid3/getid3.lib.php
+++ b/getid3/getid3.lib.php
@@ -1806,7 +1806,7 @@ class getid3_lib
 	 *
 	 * @return string
 	 */
-	public static function mb_basename($path, $suffix = null) {
+	public static function mb_basename($path, $suffix = '') {
 		$splited = preg_split('#/#', rtrim($path, '/ '));
 		return substr(basename('X'.$splited[count($splited) - 1], $suffix), 1);
 	}


### PR DESCRIPTION
The `getid3_lib::mb_basename()` method calls the PHP native `basename()` function, the second parameter of which is the _optional_ `$suffix` parameter which expects a `string`.

A parameter being optional, however, does not automatically make it nullable.

As of PHP 8.1, passing `null` to a non-nullable PHP native function will generate a deprecation notice.
In this case, this function call yielded a `basename(): Passing null to parameter #2 ($suffix) of type string is deprecated` notice.

Changing the `null` default value for the `$suffix` parameter to an empty string fixes this for _most_ cases without BC-break.
Leaving the deprecation warning in place for when calls to the function would pass `null` for the `$suffix` so they can adjust their function call.

Refs:
* https://www.php.net/manual/en/function.basename.php
* https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg