### PR TITLE
GH Actions: various tweaks

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -6,7 +6,6 @@ jobs:
   lint:
     name: "Lint"
     runs-on: "ubuntu-latest"
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
@@ -21,21 +20,15 @@ jobs:
           - "7.3"
           - "7.4"
           - "8.0"
-        experimental:
-          - false
-        include:
-          - php-version: "8.1"
-            experimental: true
-            composer-options: "--ignore-platform-reqs"
+          - "8.1"
     steps:
       - uses: "actions/checkout@v2"
       - uses: "shivammathur/setup-php@v2"
         with:
           php-version: "${{ matrix.php-version }}"
+          ini-values: error_reporting=-1, display_errors=On
           coverage: "none"
       - uses: "ramsey/composer-install@v1"
-        with:
-          composer-options: "${{ matrix.composer-options }}"
       - name: "Run the linter"
         run: "composer lint -- --colors"
 


### PR DESCRIPTION
1. Don't install against PHP 8.1 with `--ignore-platform-reqs` as it is unnecessary.
    It's not as if this repository has dependencies other than PHP Parallel Lint and it isn't needed for that.
2. Don't allow the PHP 8.1 build to fail anymore.
    The first RC for PHP 8.1 is expected next week and its not as if there are tests being run. Linting should not fail.
3. Install PHP with error reporting on full to prevent missing deprecation notices.