### PR TITLE
Declare throws on getID3 constructor

### DIFF
--- a/getid3/getid3.php
+++ b/getid3/getid3.php
@@ -393,6 +393,9 @@ class getID3
 	const ATTACHMENTS_NONE   = false;
 	const ATTACHMENTS_INLINE = true;
 
+	/**
+	 * @throws getid3_exception
+	 */
 	public function __construct() {
 
 		// Check for PHP version


### PR DESCRIPTION
This avoids that IDEs complain when wrapping getID3 in a try-catch block:

![grafik](https://user-images.githubusercontent.com/495429/134511155-2d57ab3d-0f06-4dae-a056-da1e6f69a6d7.png)
