### PR TITLE
more targeted usage of clearstatcache calls

### DIFF
--- a/getid3/write.metaflac.php
+++ b/getid3/write.metaflac.php
@@ -110,7 +110,7 @@ class getid3_write_metaflac
 
 				// On top of that, if error messages are not always captured properly under Windows
 				// To at least see if there was a problem, compare file modification timestamps before and after writing
-				clearstatcache();
+				clearstatcache(true, $this->filename);
 				$timestampbeforewriting = filemtime($this->filename);
 
 				$commandline  = GETID3_HELPERAPPSDIR.'metaflac.exe --no-utf8-convert --remove-all-tags --import-tags-from='.escapeshellarg($tempcommentsfilename);
@@ -121,7 +121,7 @@ class getid3_write_metaflac
 				$metaflacError = `$commandline`;
 
 				if (empty($metaflacError)) {
-					clearstatcache();
+					clearstatcache(true, $this->filename);
 					if ($timestampbeforewriting == filemtime($this->filename)) {
 						$metaflacError = 'File modification timestamp has not changed - it looks like the tags were not written';
 					}
@@ -173,14 +173,14 @@ class getid3_write_metaflac
 
 			if (file_exists(GETID3_HELPERAPPSDIR.'metaflac.exe')) {
 				// To at least see if there was a problem, compare file modification timestamps before and after writing
-				clearstatcache();
+				clearstatcache(true, $this->filename);
 				$timestampbeforewriting = filemtime($this->filename);
 
 				$commandline = GETID3_HELPERAPPSDIR.'metaflac.exe --remove-all-tags "'.$this->filename.'" 2>&1';
 				$metaflacError = `$commandline`;
 
 				if (empty($metaflacError)) {
-					clearstatcache();
+					clearstatcache(true, $this->filename);
 					if ($timestampbeforewriting == filemtime($this->filename)) {
 						$metaflacError = 'File modification timestamp has not changed - it looks like the tags were not deleted';
 					}

--- a/getid3/write.vorbiscomment.php
+++ b/getid3/write.vorbiscomment.php
@@ -84,14 +84,14 @@ class getid3_write_vorbiscomment
 
 				// On top of that, if error messages are not always captured properly under Windows
 				// To at least see if there was a problem, compare file modification timestamps before and after writing
-				clearstatcache();
+				clearstatcache(true, $this->filename);
 				$timestampbeforewriting = filemtime($this->filename);
 
 				$commandline = GETID3_HELPERAPPSDIR.'vorbiscomment.exe -w --raw -c "'.$tempcommentsfilename.'" "'.$this->filename.'" 2>&1';
 				$VorbiscommentError = `$commandline`;
 
 				if (empty($VorbiscommentError)) {
-					clearstatcache();
+					clearstatcache(true, $this->filename);
 					if ($timestampbeforewriting == filemtime($this->filename)) {
 						$VorbiscommentError = 'File modification timestamp has not changed - it looks like the tags were not written';
 					}


### PR DESCRIPTION
It seems that whenever `clearstatcache` is called, we are only interested in refreshing data for one file. This makes the calls less aggressive in purging filesystem metadata for all other files.