### PR TITLE
Work around divide by zero bug in MPEG-2 aspect ratio

### DIFF
--- a/getid3/module.audio-video.mpeg.php
+++ b/getid3/module.audio-video.mpeg.php
@@ -615,7 +615,7 @@ echo 'average_File_bitrate = '.number_format(array_sum($vbr_bitrates) / count($v
 			2 => array(0, 1, 1.3333, 1.7778, 2.2100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
 		);
 		$ratio = (float) (isset($lookup[$mpeg_version][$rawaspectratio]) ? $lookup[$mpeg_version][$rawaspectratio] : 0);
-		if ($mpeg_version == 2 && $ratio != 1) {
+		if ($mpeg_version == 2 && $ratio != 1 && $width != 0) {
 			// Calculate pixel aspect ratio from MPEG-2 display aspect ratio
 			$ratio = $ratio * $height / $width;
 		}


### PR DESCRIPTION
In 9ce8040f I introduced a divide-by-zero bug into the aspect
ratio handling for MPEG-2 videos. In production at Wikipedia
we've seen a few attempted uploads for files that trigger a
divide by zero on the width, which either means corrupt files
or something's wrong elsewhere.

Unfortunately our logging doesn't include the files being
uploaded, so I don't have a test case to analyze. But this
workaround will at least avoid a fatal error that can't be
caught.

On our bug tracker: https://phabricator.wikimedia.org/T289189