### PR TITLE
The type has been identified. ($BitrateCache[$FrameLength]])

### DIFF
--- a/getid3/module.audio.aac.php
+++ b/getid3/module.audio.aac.php
@@ -400,7 +400,7 @@ class getid3_aac extends getid3_handler
 			if (!isset($BitrateCache[$FrameLength])) {
 				$BitrateCache[$FrameLength] = ($info['aac']['header']['sample_frequency'] / 1024) * $FrameLength * 8;
 			}
-			getid3_lib::safe_inc($info['aac']['bitrate_distribution'][$BitrateCache[$FrameLength]], 1);
+			getid3_lib::safe_inc($info['aac']['bitrate_distribution'][(string)$BitrateCache[$FrameLength]], 1);
 
 			$info['aac'][$framenumber]['aac_frame_length']     = $FrameLength;
 


### PR DESCRIPTION
Enviroment Information
Server Laragon / Apache
Php Version: 8.1.2

Error:
Deprecated:  Implicit conversion from float 107493.75 to int loses precision in C:\laragon\www\getID3\getid3\module.audio.aac.php on line 403

File:
https://filesamples.com/samples/audio/aac/sample4.aac