### PR TITLE
GH Actions: run lint against PHP 8.2

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,6 +21,7 @@ jobs:
           - "7.4"
           - "8.0"
           - "8.1"
+          - "8.2"
     steps:
       - uses: "actions/checkout@v2"
       - uses: "shivammathur/setup-php@v2"

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "ext-zlib": "Zlib extension is required for archive modules and compressed metadata."
     },
     "scripts": {
-        "lint": "parallel-lint --exclude vendor --exclude .git .",
+        "lint": "parallel-lint --show-deprecated --exclude vendor --exclude .git .",
         "test": [
             "composer lint"
         ]


### PR DESCRIPTION
The first alpha of PHP 8.2 was released nearly two weeks ago, so let's start linting against PHP 8.2

Includes enabling the `--show-deprecated` option.

While rare, there are some deprecations which PHP can show when a file is being linted. By default these are ignored by PHP-Parallel-Lint.