### PR TITLE
Guard against division by zero

### DIFF
--- a/getid3/getid3.lib.php
+++ b/getid3/getid3.lib.php
@@ -128,6 +128,18 @@ class getid3_lib
 	}
 
 	/**
+	 * Perform a division, guarding against division by zero
+	 *
+	 * @param float|int $numerator
+	 * @param float|int $denominator
+	 * @param float|int $fallback
+	 * @return float|int
+	 */
+	public static function SafeDiv($numerator, $denominator, $fallback = 0) {
+		return $denominator ? $numerator / $denominator : $fallback;
+	}
+
+	/**
 	 * @param string $fraction
 	 *
 	 * @return float

--- a/getid3/getid3.php
+++ b/getid3/getid3.php
@@ -1977,7 +1977,7 @@ class getID3
 		}
 		$BitrateUncompressed = $this->info['video']['resolution_x'] * $this->info['video']['resolution_y'] * $this->info['video']['bits_per_sample'] * $FrameRate;
 
-		$this->info['video']['compression_ratio'] = $BitrateCompressed / $BitrateUncompressed;
+		$this->info['video']['compression_ratio'] = getid3_lib::SafeDiv($BitrateCompressed, $BitrateUncompressed, 1);
 		return true;
 	}
 

--- a/getid3/module.archive.hpk.php
+++ b/getid3/module.archive.hpk.php
@@ -43,7 +43,7 @@ class getid3_hpk extends getid3_handler
 			$info['hpk']['header']['fragmented_filesystem_offset'] = getid3_lib::LittleEndian2Int(substr($HPKheader, 28, 4));
 			$info['hpk']['header']['fragmented_filesystem_length'] = getid3_lib::LittleEndian2Int(substr($HPKheader, 32, 4));
 
-			$info['hpk']['header']['filesystem_entries'] = $info['hpk']['header']['fragmented_filesystem_length'] / ($info['hpk']['header']['fragments_per_file'] * 8);
+			$info['hpk']['header']['filesystem_entries'] = getid3_lib::SafeDiv($info['hpk']['header']['fragmented_filesystem_length'], $info['hpk']['header']['fragments_per_file'] * 8);
 			$this->fseek($info['hpk']['header']['fragmented_filesystem_offset']);
 			for ($i = 0; $i < $info['hpk']['header']['filesystem_entries']; $i++) {
 				$offset = getid3_lib::LittleEndian2Int($this->fread(4));

--- a/getid3/module.audio-video.asf.php
+++ b/getid3/module.audio-video.asf.php
@@ -193,7 +193,7 @@ class getid3_asf extends getid3_handler
 						$info['playtime_seconds'] = ($thisfile_asf_filepropertiesobject['play_duration'] / 10000000) - ($thisfile_asf_filepropertiesobject['preroll'] / 1000);
 
 						//$info['bitrate'] = $thisfile_asf_filepropertiesobject['max_bitrate'];
-						$info['bitrate'] = ($thisfile_asf_filepropertiesobject['filesize'] * 8) / $info['playtime_seconds'];
+						$info['bitrate'] = getid3_lib::SafeDiv($thisfile_asf_filepropertiesobject['filesize'] * 8, $info['playtime_seconds']);
 					}
 					break;
 

--- a/getid3/module.audio-video.ivf.php
+++ b/getid3/module.audio-video.ivf.php
@@ -45,7 +45,7 @@ class getid3_ivf extends getid3_handler
 			$info['ivf']['header']['frame_count']          = getid3_lib::LittleEndian2Int(substr($IVFheader, 24, 4));
 			//$info['ivf']['header']['reserved']             =                              substr($IVFheader, 28, 4);
 
-			$info['ivf']['header']['frame_rate'] = (float) $info['ivf']['header']['timebase_numerator'] / $info['ivf']['header']['timebase_denominator'];
+			$info['ivf']['header']['frame_rate'] = (float)getid3_lib::SafeDiv($info['ivf']['header']['timebase_denominator'], $info['ivf']['header']['timebase_denominator']);
 
 			if ($info['ivf']['header']['version'] > 0) {
 				$this->warning('Expecting IVF header version 0, found version '.$info['ivf']['header']['version'].', results may not be accurate');
@@ -65,7 +65,7 @@ class getid3_ivf extends getid3_handler
 					$info['ivf']['frame_count']++;
 				}
 			}
-			if ($info['ivf']['frame_count']) {
+			if ($info['ivf']['frame_count'] && $info['playtime_seconds']) {
 				$info['playtime_seconds']    = $timestamp / 100000;
 				$info['video']['frame_rate'] = (float) $info['ivf']['frame_count'] / $info['playtime_seconds'];
 			}

--- a/getid3/module.audio-video.ivf.php
+++ b/getid3/module.audio-video.ivf.php
@@ -45,7 +45,7 @@ class getid3_ivf extends getid3_handler
 			$info['ivf']['header']['frame_count']          = getid3_lib::LittleEndian2Int(substr($IVFheader, 24, 4));
 			//$info['ivf']['header']['reserved']             =                              substr($IVFheader, 28, 4);
 
-			$info['ivf']['header']['frame_rate'] = (float)getid3_lib::SafeDiv($info['ivf']['header']['timebase_denominator'], $info['ivf']['header']['timebase_denominator']);
+			$info['ivf']['header']['frame_rate'] = (float)getid3_lib::SafeDiv($info['ivf']['header']['timebase_numerator'], $info['ivf']['header']['timebase_denominator']);
 
 			if ($info['ivf']['header']['version'] > 0) {
 				$this->warning('Expecting IVF header version 0, found version '.$info['ivf']['header']['version'].', results may not be accurate');

--- a/getid3/module.audio-video.matroska.php
+++ b/getid3/module.audio-video.matroska.php
@@ -292,12 +292,12 @@ class getid3_matroska extends getid3_handler
 						$track_info['display_x']    = (isset($trackarray['DisplayWidth']) ? $trackarray['DisplayWidth'] : $trackarray['PixelWidth']);
 						$track_info['display_y']    = (isset($trackarray['DisplayHeight']) ? $trackarray['DisplayHeight'] : $trackarray['PixelHeight']);
 
-						if (isset($trackarray['PixelCropBottom'])) { $track_info['crop_bottom'] = $trackarray['PixelCropBottom']; }
-						if (isset($trackarray['PixelCropTop']))    { $track_info['crop_top']    = $trackarray['PixelCropTop']; }
-						if (isset($trackarray['PixelCropLeft']))   { $track_info['crop_left']   = $trackarray['PixelCropLeft']; }
-						if (isset($trackarray['PixelCropRight']))  { $track_info['crop_right']  = $trackarray['PixelCropRight']; }
-						if (isset($trackarray['DefaultDuration'])) { $track_info['frame_rate']  = round(1000000000 / $trackarray['DefaultDuration'], 3); }
-						if (isset($trackarray['CodecName']))       { $track_info['codec']       = $trackarray['CodecName']; }
+						if (isset($trackarray['PixelCropBottom']))  { $track_info['crop_bottom'] = $trackarray['PixelCropBottom']; }
+						if (isset($trackarray['PixelCropTop']))     { $track_info['crop_top']    = $trackarray['PixelCropTop']; }
+						if (isset($trackarray['PixelCropLeft']))    { $track_info['crop_left']   = $trackarray['PixelCropLeft']; }
+						if (isset($trackarray['PixelCropRight']))   { $track_info['crop_right']  = $trackarray['PixelCropRight']; }
+						if (!empty($trackarray['DefaultDuration'])) { $track_info['frame_rate']  = round(1000000000 / $trackarray['DefaultDuration'], 3); }
+						if (isset($trackarray['CodecName']))        { $track_info['codec']       = $trackarray['CodecName']; }
 
 						switch ($trackarray['CodecID']) {
 							case 'V_MS/VFW/FOURCC':

--- a/getid3/module.audio-video.mpeg.php
+++ b/getid3/module.audio-video.mpeg.php
@@ -505,9 +505,9 @@ echo 'average_File_bitrate = '.number_format(array_sum($vbr_bitrates) / count($v
 			$last_GOP_id = max(array_keys($FramesByGOP));
 			$frames_in_last_GOP = count($FramesByGOP[$last_GOP_id]);
 			$gopdata = &$info['mpeg']['group_of_pictures'][$last_GOP_id];
-			$info['playtime_seconds'] = ($gopdata['time_code_hours'] * 3600) + ($gopdata['time_code_minutes'] * 60) + $gopdata['time_code_seconds'] + (($gopdata['time_code_pictures'] + $frames_in_last_GOP + 1) / $info['mpeg']['video']['frame_rate']);
+			$info['playtime_seconds'] = ($gopdata['time_code_hours'] * 3600) + ($gopdata['time_code_minutes'] * 60) + $gopdata['time_code_seconds'] + getid3_lib::SafeDiv($gopdata['time_code_pictures'] + $frames_in_last_GOP + 1, $info['mpeg']['video']['frame_rate']);
 			if (!isset($info['video']['bitrate'])) {
-				$overall_bitrate = ($info['avdataend'] - $info['avdataoffset']) * 8 / $info['playtime_seconds'];
+				$overall_bitrate = getid3_lib::SafeDiv($info['avdataend'] - $info['avdataoffset'] * 8, $info['playtime_seconds']);
 				$info['video']['bitrate'] = $overall_bitrate - (isset($info['audio']['bitrate']) ? $info['audio']['bitrate'] : 0);
 			}
 			unset($info['mpeg']['group_of_pictures']);

--- a/getid3/module.audio-video.nsv.php
+++ b/getid3/module.audio-video.nsv.php
@@ -215,7 +215,7 @@ class getid3_nsv extends getid3_handler
 		}
 
 		$info['playtime_seconds'] = $info['nsv']['NSVf']['playtime_ms'] / 1000;
-		$info['bitrate']          = ($info['nsv']['NSVf']['file_size'] * 8) / $info['playtime_seconds'];
+		$info['bitrate']          = getid3_lib::SafeDiv($info['nsv']['NSVf']['file_size'] * 8, $info['playtime_seconds']);
 
 		return true;
 	}

--- a/getid3/module.audio-video.real.php
+++ b/getid3/module.audio-video.real.php
@@ -47,8 +47,13 @@ class getid3_real extends getid3_handler
 					$info['audio']['bits_per_sample'] = $info['real']['old_ra_header']['bits_per_sample'];
 					$info['audio']['channels']        = $info['real']['old_ra_header']['channels'];
 
-					$info['playtime_seconds']         = 60 * ($info['real']['old_ra_header']['audio_bytes'] / $info['real']['old_ra_header']['bytes_per_minute']);
-					$info['audio']['bitrate']         =  8 * ($info['real']['old_ra_header']['audio_bytes'] / $info['playtime_seconds']);
+					if ($info['real']['old_ra_header']['bytes_per_minute']) {
+						$info['playtime_seconds']     = 60 * ($info['real']['old_ra_header']['audio_bytes'] / $info['real']['old_ra_header']['bytes_per_minute']);
+						$info['audio']['bitrate']     = 8 * ($info['real']['old_ra_header']['audio_bytes'] / $info['playtime_seconds']);
+					} else {
+						$info['playtime_seconds']     = 0;
+						$info['audio']['bitrate']     = 0;
+					}
 					$info['audio']['codec']           = $this->RealAudioCodecFourCClookup($info['real']['old_ra_header']['fourcc'], $info['audio']['bitrate']);
 
 					foreach ($info['real']['old_ra_header']['comments'] as $key => $valuearray) {

--- a/getid3/module.audio-video.riff.php
+++ b/getid3/module.audio-video.riff.php
@@ -214,7 +214,7 @@ class getid3_riff extends getid3_handler
 					$thisfile_audio['bitrate'] = $thisfile_riff_audio[$streamindex]['bitrate'];
 
 					if (empty($info['playtime_seconds'])) { // may already be set (e.g. DTS-WAV)
-						$info['playtime_seconds'] = (float) ((($info['avdataend'] - $info['avdataoffset']) * 8) / $thisfile_audio['bitrate']);
+						$info['playtime_seconds'] =  (float)getid3_lib::SafeDiv(($info['avdataend'] - $info['avdataoffset']) * 8, $thisfile_audio['bitrate']);
 					}
 
 					$thisfile_audio['lossless'] = false;
@@ -521,7 +521,7 @@ class getid3_riff extends getid3_handler
 
 				if (!isset($thisfile_audio['bitrate']) && isset($thisfile_riff_audio[$streamindex]['bitrate'])) {
 					$thisfile_audio['bitrate'] = $thisfile_riff_audio[$streamindex]['bitrate'];
-					$info['playtime_seconds'] = (float) ((($info['avdataend'] - $info['avdataoffset']) * 8) / $thisfile_audio['bitrate']);
+					$info['playtime_seconds'] = (float)getid3_lib::SafeDiv((($info['avdataend'] - $info['avdataoffset']) * 8), $thisfile_audio['bitrate']);
 				}
 
 				if (!empty($info['wavpack'])) {
@@ -531,7 +531,7 @@ class getid3_riff extends getid3_handler
 
 					// Reset to the way it was - RIFF parsing will have messed this up
 					$info['avdataend']        = $Original['avdataend'];
-					$thisfile_audio['bitrate'] = (($info['avdataend'] - $info['avdataoffset']) * 8) / $info['playtime_seconds'];
+					$thisfile_audio['bitrate'] = getid3_lib::SafeDiv(($info['avdataend'] - $info['avdataoffset']) * 8, $info['playtime_seconds']);
 
 					$this->fseek($info['avdataoffset'] - 44);
 					$RIFFdata = $this->fread(44);

--- a/getid3/module.audio.amr.php
+++ b/getid3/module.audio.amr.php
@@ -62,7 +62,7 @@ class getid3_amr extends getid3_handler
 		} while (strlen($buffer) > 0);
 
 		$info['playtime_seconds'] = array_sum($thisfile_amr['frame_mode_count']) * 0.020; // each frame contain 160 samples and is 20 milliseconds long
-		$info['audio']['bitrate'] = (8 * ($info['avdataend'] - $info['avdataoffset'])) / $info['playtime_seconds']; // bitrate could be calculated from average bitrate by distributation of frame types. That would give effective audio bitrate, this gives overall file bitrate which will be a little bit higher since every frame will waste 8 bits for header, plus a few bits for octet padding
+		$info['audio']['bitrate'] = getid3_lib::SafeDiv(8 * ($info['avdataend'] - $info['avdataoffset']), $info['playtime_seconds']); // bitrate could be calculated from average bitrate by distributation of frame types. That would give effective audio bitrate, this gives overall file bitrate which will be a little bit higher since every frame will waste 8 bits for header, plus a few bits for octet padding
 		$info['bitrate'] = $info['audio']['bitrate'];
 
 		return true;

--- a/getid3/module.audio.au.php
+++ b/getid3/module.audio.au.php
@@ -69,8 +69,8 @@ class getid3_au extends getid3_handler
 			$this->warning('Possible truncated file - expecting "'.$thisfile_au['data_size'].'" bytes of audio data, only found '.($info['avdataend'] - $info['avdataoffset']).' bytes"');
 		}
 
-		$info['playtime_seconds'] = $thisfile_au['data_size'] / ($thisfile_au['sample_rate'] * $thisfile_au['channels'] * ($thisfile_au['used_bits_per_sample'] / 8));
-		$info['audio']['bitrate'] = ($thisfile_au['data_size'] * 8) / $info['playtime_seconds'];
+		$info['audio']['bitrate'] = $thisfile_au['sample_rate'] * $thisfile_au['channels'] * $thisfile_au['used_bits_per_sample'];
+		$info['playtime_seconds'] = getid3_lib::SafeDiv($thisfile_au['data_size'], $info['audio']['bitrate'] / 8);
 
 		return true;
 	}

--- a/getid3/module.audio.avr.php
+++ b/getid3/module.audio.avr.php
@@ -120,9 +120,9 @@ class getid3_avr extends getid3_handler
 		$info['audio']['bits_per_sample'] = $info['avr']['bits_per_sample'];
 		$info['audio']['sample_rate']     = $info['avr']['sample_rate'];
 		$info['audio']['channels']        = ($info['avr']['flags']['stereo'] ? 2 : 1);
-		$info['playtime_seconds']         = ($info['avr']['sample_length'] / $info['audio']['channels']) / $info['avr']['sample_rate'];
-		$info['audio']['bitrate']         = ($info['avr']['sample_length'] * (($info['avr']['bits_per_sample'] == 8) ? 8 : 16)) / $info['playtime_seconds'];
-
+		$bits_per_sample                  = ($info['avr']['bits_per_sample'] == 8) ? 8 : 16;
+		$info['audio']['bitrate']         = $bits_per_sample * $info['audio']['channels'] * $info['avr']['sample_rate'];
+		$info['playtime_seconds']         = getid3_lib::SafeDiv($info['avr']['sample_length'] * $bits_per_sample, $info['audio']['bitrate']);
 
 		return true;
 	}

--- a/getid3/module.audio.bonk.php
+++ b/getid3/module.audio.bonk.php
@@ -154,7 +154,7 @@ class getid3_bonk extends getid3_handler
 				$info['audio']['lossless']        = $thisfile_bonk_BONK['lossless'];
 				$info['audio']['codec']           = 'bonk';
 
-				$info['playtime_seconds'] = $thisfile_bonk_BONK['number_samples'] / ($thisfile_bonk_BONK['sample_rate'] * $thisfile_bonk_BONK['channels']);
+				$info['playtime_seconds'] = getid3_lib::SafeDiv($thisfile_bonk_BONK['number_samples'], $thisfile_bonk_BONK['sample_rate'] * $thisfile_bonk_BONK['channels']);
 				if ($info['playtime_seconds'] > 0) {
 					$info['audio']['bitrate'] = (($info['bonk']['dataend'] - $info['bonk']['dataoffset']) * 8) / $info['playtime_seconds'];
 				}

--- a/getid3/module.audio.dsf.php
+++ b/getid3/module.audio.dsf.php
@@ -115,7 +115,7 @@ class getid3_dsf extends getid3_handler
 		$info['audio']['sample_rate']       = $info['dsf']['fmt']['sample_rate'];
 		$info['audio']['channels']          = $info['dsf']['fmt']['channels'];
 		$info['audio']['bitrate']           = $info['audio']['bits_per_sample'] * $info['audio']['sample_rate'] * $info['audio']['channels'];
-		$info['playtime_seconds']           = ($info['dsf']['data']['data_chunk_size'] * 8) / $info['audio']['bitrate'];
+		$info['playtime_seconds']           = getid3_lib::SafeDiv($info['dsf']['data']['data_chunk_size'] * 8, $info['audio']['bitrate']);
 
 		return true;
 	}

--- a/getid3/module.audio.lpac.php
+++ b/getid3/module.audio.lpac.php
@@ -126,8 +126,8 @@ class getid3_lpac extends getid3_handler
 			}
 		}
 
-		$info['playtime_seconds'] = $info['lpac']['total_samples'] / $info['audio']['sample_rate'];
-		$info['audio']['bitrate'] = (($info['avdataend'] - $info['avdataoffset']) * 8) / $info['playtime_seconds'];
+		$info['playtime_seconds'] = getid3_lib::SafeDiv($info['lpac']['total_samples'], $info['audio']['sample_rate']);
+		$info['audio']['bitrate'] = getid3_lib::SafeDiv(($info['avdataend'] - $info['avdataoffset']) * 8, $info['playtime_seconds']);
 
 		return true;
 	}

--- a/getid3/module.audio.midi.php
+++ b/getid3/module.audio.midi.php
@@ -99,7 +99,6 @@ class getid3_midi extends getid3_handler
 			$thisfile_midi['totalticks']      = 0;
 			$info['playtime_seconds'] = 0;
 			$CurrentMicroSecondsPerBeat       = 500000; // 120 beats per minute;  60,000,000 microseconds per minute -> 500,000 microseconds per beat
-			$CurrentBeatsPerMinute            = 120;    // 120 beats per minute;  60,000,000 microseconds per minute -> 500,000 microseconds per beat
 			$MicroSecondsPerQuarterNoteAfter  = array ();
 			$MIDIevents                       = array();
 
@@ -244,7 +243,6 @@ class getid3_midi extends getid3_handler
 									return false;
 								}
 								$thisfile_midi_raw['events'][$tracknumber][$CumulativeDeltaTime]['us_qnote'] = $CurrentMicroSecondsPerBeat;
-								$CurrentBeatsPerMinute = (1000000 / $CurrentMicroSecondsPerBeat) * 60;
 								$MicroSecondsPerQuarterNoteAfter[$CumulativeDeltaTime] = $CurrentMicroSecondsPerBeat;
 								$TicksAtCurrentBPM = 0;
 								break;

--- a/getid3/module.audio.mpc.php
+++ b/getid3/module.audio.mpc.php
@@ -137,7 +137,7 @@ class getid3_mpc extends getid3_handler
 					$info['audio']['channels']    = $thisPacket['channels'];
 					$info['audio']['sample_rate'] = $thisPacket['sample_frequency'];
 					$info['playtime_seconds'] = $thisPacket['sample_count'] / $thisPacket['sample_frequency'];
-					$info['audio']['bitrate'] = (($info['avdataend'] - $info['avdataoffset']) * 8) / $info['playtime_seconds'];
+					$info['audio']['bitrate'] = getid3_lib::SafeDiv(($info['avdataend'] - $info['avdataoffset']) * 8, $info['playtime_seconds']);
 					break;
 
 				case 'RG': // Replay Gain
@@ -282,7 +282,7 @@ class getid3_mpc extends getid3_handler
 		$info['audio']['sample_rate'] = $thisfile_mpc_header['sample_rate'];
 		$thisfile_mpc_header['samples']       = ((($thisfile_mpc_header['frame_count'] - 1) * 1152) + $thisfile_mpc_header['last_frame_length']) * $info['audio']['channels'];
 
-		$info['playtime_seconds']     = ($thisfile_mpc_header['samples'] / $info['audio']['channels']) / $info['audio']['sample_rate'];
+		$info['playtime_seconds']     = getid3_lib::SafeDiv($thisfile_mpc_header['samples'], $info['audio']['channels'] * $info['audio']['sample_rate']);
 		if ($info['playtime_seconds'] == 0) {
 			$this->error('Corrupt MPC file: playtime_seconds == zero');
 			return false;

--- a/getid3/module.audio.ogg.php
+++ b/getid3/module.audio.ogg.php
@@ -210,8 +210,8 @@ $this->warning('Ogg Theora (v3) not fully supported in this version of getID3 ['
 			$filedataoffset += 20;
 
 			$info['ogg']['skeleton']['fishead']['version']          = $info['ogg']['skeleton']['fishead']['raw']['version_major'].'.'.$info['ogg']['skeleton']['fishead']['raw']['version_minor'];
-			$info['ogg']['skeleton']['fishead']['presentationtime'] = $info['ogg']['skeleton']['fishead']['raw']['presentationtime_numerator'] / $info['ogg']['skeleton']['fishead']['raw']['presentationtime_denominator'];
-			$info['ogg']['skeleton']['fishead']['basetime']         = $info['ogg']['skeleton']['fishead']['raw']['basetime_numerator']         / $info['ogg']['skeleton']['fishead']['raw']['basetime_denominator'];
+			$info['ogg']['skeleton']['fishead']['presentationtime'] = getid3_lib::SafeDiv($info['ogg']['skeleton']['fishead']['raw']['presentationtime_numerator'], $info['ogg']['skeleton']['fishead']['raw']['presentationtime_denominator']);
+			$info['ogg']['skeleton']['fishead']['basetime']         = getid3_lib::SafeDiv($info['ogg']['skeleton']['fishead']['raw']['basetime_numerator'],         $info['ogg']['skeleton']['fishead']['raw']['basetime_denominator']);
 			$info['ogg']['skeleton']['fishead']['utc']              = $info['ogg']['skeleton']['fishead']['raw']['utc'];
 
 
@@ -288,7 +288,7 @@ $this->warning('Ogg Theora (v3) not fully supported in this version of getID3 ['
 				$info['audio']['sample_rate']     = $info['flac']['STREAMINFO']['sample_rate'];
 				$info['audio']['channels']        = $info['flac']['STREAMINFO']['channels'];
 				$info['audio']['bits_per_sample'] = $info['flac']['STREAMINFO']['bits_per_sample'];
-				$info['playtime_seconds']         = $info['flac']['STREAMINFO']['samples_stream'] / $info['flac']['STREAMINFO']['sample_rate'];
+				$info['playtime_seconds']         = getid3_lib::SafeDiv($info['flac']['STREAMINFO']['samples_stream'], $info['flac']['STREAMINFO']['sample_rate']);
 			}
 
 		} else {
@@ -359,7 +359,7 @@ $this->warning('Ogg Theora (v3) not fully supported in this version of getID3 ['
 					return false;
 				}
 				if (!empty($info['audio']['sample_rate'])) {
-					$info['ogg']['bitrate_average'] = (($info['avdataend'] - $info['avdataoffset']) * 8) / ($info['ogg']['samples'] / $info['audio']['sample_rate']);
+					$info['ogg']['bitrate_average'] = (($info['avdataend'] - $info['avdataoffset']) * 8) * $info['audio']['sample_rate'] / $info['ogg']['samples'];
 				}
 			}
 

--- a/getid3/module.audio.rkau.php
+++ b/getid3/module.audio.rkau.php
@@ -75,7 +75,7 @@ class getid3_rkau extends getid3_handler
 		$info['audio']['sample_rate']     = $info['rkau']['sample_rate'];
 
 		$info['playtime_seconds']         = $info['rkau']['source_bytes'] / ($info['rkau']['sample_rate'] * $info['rkau']['channels'] * ($info['rkau']['bits_per_sample'] / 8));
-		$info['audio']['bitrate']         = ($info['rkau']['compressed_bytes'] * 8) / $info['playtime_seconds'];
+		$info['audio']['bitrate']         = getid3_lib::SafeDiv($info['rkau']['compressed_bytes'] * 8, $info['playtime_seconds']);
 
 		return true;
 

--- a/getid3/module.audio.shorten.php
+++ b/getid3/module.audio.shorten.php
@@ -166,7 +166,7 @@ class getid3_shorten extends getid3_handler
 
 			if (substr($output, 20 + $fmt_size, 4) == 'data') {
 
-				$info['playtime_seconds'] = getid3_lib::LittleEndian2Int(substr($output, 20 + 4 + $fmt_size, 4)) / $DecodedWAVFORMATEX['raw']['nAvgBytesPerSec'];
+				$info['playtime_seconds'] = getid3_lib::SafeDiv(getid3_lib::LittleEndian2Int(substr($output, 20 + 4 + $fmt_size, 4)), $DecodedWAVFORMATEX['raw']['nAvgBytesPerSec']);
 
 			} else {
 
@@ -175,7 +175,7 @@ class getid3_shorten extends getid3_handler
 
 			}
 
-			$info['audio']['bitrate'] = (($info['avdataend'] - $info['avdataoffset']) / $info['playtime_seconds']) * 8;
+			$info['audio']['bitrate'] = getid3_lib::SafeDiv($info['avdataend'] - $info['avdataoffset'], $info['playtime_seconds']) * 8;
 
 		} else {
 

--- a/getid3/module.audio.tta.php
+++ b/getid3/module.audio.tta.php
@@ -59,7 +59,7 @@ class getid3_tta extends getid3_handler
 				$info['tta']['samples_per_channel'] = getid3_lib::LittleEndian2Int(substr($ttaheader, 12,  4));
 
 				$info['audio']['encoder_options']   = '-e'.$info['tta']['compression_level'];
-				$info['playtime_seconds']           = $info['tta']['samples_per_channel'] / $info['tta']['sample_rate'];
+				$info['playtime_seconds']           = getid3_lib::SafeDiv($info['tta']['samples_per_channel'], $info['tta']['sample_rate']);
 				break;
 
 			case '2': // TTA v2.x
@@ -75,7 +75,7 @@ class getid3_tta extends getid3_handler
 				$info['tta']['data_length']         = getid3_lib::LittleEndian2Int(substr($ttaheader, 16,  4));
 
 				$info['audio']['encoder_options']   = '-e'.$info['tta']['compression_level'];
-				$info['playtime_seconds']           = $info['tta']['data_length'] / $info['tta']['sample_rate'];
+				$info['playtime_seconds']           = getid3_lib::SafeDiv($info['tta']['data_length'], $info['tta']['sample_rate']);
 				break;
 
 			case '1': // TTA v3.x
@@ -91,7 +91,7 @@ class getid3_tta extends getid3_handler
 				$info['tta']['crc32_footer']        =                              substr($ttaheader, 18,  4);
 				$info['tta']['seek_point']          = getid3_lib::LittleEndian2Int(substr($ttaheader, 22,  4));
 
-				$info['playtime_seconds']           = $info['tta']['data_length'] / $info['tta']['sample_rate'];
+				$info['playtime_seconds']           = getid3_lib::SafeDiv($info['tta']['data_length'], $info['tta']['sample_rate']);
 				break;
 
 			default:
@@ -103,7 +103,7 @@ class getid3_tta extends getid3_handler
 		$info['audio']['bits_per_sample'] = $info['tta']['bits_per_sample'];
 		$info['audio']['sample_rate']     = $info['tta']['sample_rate'];
 		$info['audio']['channels']        = $info['tta']['channels'];
-		$info['audio']['bitrate']         = (($info['avdataend'] - $info['avdataoffset']) * 8) / $info['playtime_seconds'];
+		$info['audio']['bitrate']         = getid3_lib::SafeDiv(($info['avdataend'] - $info['avdataoffset']) * 8, $info['playtime_seconds']);
 
 		return true;
 	}

--- a/getid3/module.audio.voc.php
+++ b/getid3/module.audio.voc.php
@@ -140,7 +140,7 @@ class getid3_voc extends getid3_handler
 
 					$thisfile_audio['sample_rate']     = $ThisBlock['sample_rate'];
 					$thisfile_audio['bits_per_sample'] = $ThisBlock['bits_per_sample'];
-					$thisfile_audio['channels']        = $ThisBlock['channels'];
+					$thisfile_audio['channels']        = $ThisBlock['channels'] ?: 1;
 					break;
 
 				default:
@@ -164,8 +164,8 @@ class getid3_voc extends getid3_handler
 		ksort($thisfile_voc['blocktypes']);
 
 		if (!empty($thisfile_voc['compressed_bits_per_sample'])) {
-			$info['playtime_seconds'] = (($info['avdataend'] - $info['avdataoffset']) * 8) / ($thisfile_voc['compressed_bits_per_sample'] * $thisfile_audio['channels'] * $thisfile_audio['sample_rate']);
-			$thisfile_audio['bitrate'] = (($info['avdataend'] - $info['avdataoffset']) * 8) / $info['playtime_seconds'];
+			$info['playtime_seconds'] = getid3_lib::SafeDiv(($info['avdataend'] - $info['avdataoffset']) * 8, $thisfile_voc['compressed_bits_per_sample'] * $thisfile_audio['channels'] * $thisfile_audio['sample_rate']);
+			$thisfile_audio['bitrate'] = getid3_lib::SafeDiv(($info['avdataend'] - $info['avdataoffset']) * 8, $info['playtime_seconds']);
 		}
 
 		return true;

--- a/getid3/module.audio.wavpack.php
+++ b/getid3/module.audio.wavpack.php
@@ -243,7 +243,7 @@ class getid3_wavpack extends getid3_handler
 
 							$metablock['riff']['original_filesize'] = $original_wav_filesize;
 							$info['wavpack']['riff_trailer_size'] = $original_wav_filesize - $metablock['riff']['WAVE']['data'][0]['size'] - $metablock['riff']['header_size'];
-							$info['playtime_seconds'] = $info['wavpack']['blockheader']['total_samples'] / $info['audio']['sample_rate'];
+							$info['playtime_seconds'] = getid3_lib::SafeDiv($info['wavpack']['blockheader']['total_samples'], $info['audio']['sample_rate']);
 
 							// Safe RIFF header in case there's a RIFF footer later
 							$metablockRIFFheader = $metablock['data'];


### PR DESCRIPTION
* Add getid3_lib::SafeDiv() which does a division with ternary guard.
  Avoids repeating the denominator expression.
* Rearrange a few formulas to avoid unnecessary divisions.
  a/(b/c) = a*c/b except that the latter produces an answer when c=0.
* Remediate divisions that may possibly divide by zero, or look
  suspicious.
* In module.audio.midi.php: remove unused variable
* In module.audio.mp3.php: raise an error for zero channels, since lots
  of things divide by the channel count.
* In module.audio.voc.php: ignore channels=0, pretend channels=1
* In module.graphic.bmp.php: with ExtractData the RLE modes will divide
  by zero if width=0. With any compression mode, zero width or height
  means empty data, so add that as a shortcut.

Motivation: https://phabricator.wikimedia.org/T289189
