### PR TITLE
Filter out null value before CastAsAppropriate() to prevent deprecati…

### DIFF
--- a/getid3/module.graphic.jpg.php
+++ b/getid3/module.graphic.jpg.php
@@ -98,7 +98,7 @@ class getid3_jpg extends getid3_handler
 		$cast_as_appropriate_keys = array('EXIF', 'IFD0', 'THUMBNAIL');
 		foreach ($cast_as_appropriate_keys as $exif_key) {
 			if (isset($info['jpg']['exif'][$exif_key])) {
-				foreach ($info['jpg']['exif'][$exif_key] as $key => $value) {
+				foreach (array_filter($info['jpg']['exif'][$exif_key]) as $key => $value) {
 					$info['jpg']['exif'][$exif_key][$key] = $this->CastAsAppropriate($value);
 				}
 			}


### PR DESCRIPTION
Filter out null value before CastAsAppropriate() to prevent deprecation notices for preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in getid3_jpg->CastAsAppropriate()