### PR TITLE
Fix for MPEG-1 video pixel aspect ratio

### DIFF
--- a/getid3/module.audio-video.mpeg.php
+++ b/getid3/module.audio-video.mpeg.php
@@ -618,6 +618,9 @@ echo 'average_File_bitrate = '.number_format(array_sum($vbr_bitrates) / count($v
 		if ($mpeg_version == 2 && $ratio != 1 && $width != 0) {
 			// Calculate pixel aspect ratio from MPEG-2 display aspect ratio
 			$ratio = $ratio * $height / $width;
+		} else if ($ratio > 0) {
+			// The MPEG-1 tables store the reciprocal of the pixel aspect ratio.
+			$ratio = 1 / $ratio;
 		}
 		return $ratio;
 	}

--- a/getid3/module.audio-video.mpeg.php
+++ b/getid3/module.audio-video.mpeg.php
@@ -621,7 +621,7 @@ echo 'average_File_bitrate = '.number_format(array_sum($vbr_bitrates) / count($v
 		if ($mpeg_version == 2 && $ratio != 1 && $width != 0) {
 			// Calculate pixel aspect ratio from MPEG-2 display aspect ratio
 			$ratio = $ratio * $height / $width;
-		} else if ($ratio > 0) {
+		} else if ($ratio != 0) {
 			// The MPEG-1 tables store the reciprocal of the pixel aspect ratio.
 			$ratio = 1 / $ratio;
 		}

--- a/getid3/module.audio-video.mpeg.php
+++ b/getid3/module.audio-video.mpeg.php
@@ -610,8 +610,11 @@ echo 'average_File_bitrate = '.number_format(array_sum($vbr_bitrates) / count($v
 	 * @return float
 	 */
 	public static function videoAspectRatioLookup($rawaspectratio, $mpeg_version=1, $width=0, $height=0) {
+		// Per http://forum.doom9.org/archive/index.php/t-84400.html
+		// 0.9157 is commonly accepted to mean 11/12 or .9166, the reciprocal of 12/11 (1.091) and,
+		// 1.0950 is commonly accepted to mean 11/10 or 1.1, the reciprocal of 10/11 (0.909)
 		$lookup = array(
-			1 => array(0, 1, 0.6735, 0.7031, 0.7615, 0.8055, 0.8437, 0.8935, 0.9157, 0.9815, 1.0255, 1.0695, 1.0950, 1.1575, 1.2015, 0),
+			1 => array(0, 1, 0.6735, 0.7031, 0.7615, 0.8055, 0.8437, 0.8935, 11/12, 0.9815, 1.0255, 1.0695, 11/10, 1.1575, 1.2015, 0),
 			2 => array(0, 1, 1.3333, 1.7778, 2.2100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
 		);
 		$ratio = (float) (isset($lookup[$mpeg_version][$rawaspectratio]) ? $lookup[$mpeg_version][$rawaspectratio] : 0);

--- a/getid3/module.audio-video.mpeg.php
+++ b/getid3/module.audio-video.mpeg.php
@@ -621,7 +621,7 @@ echo 'average_File_bitrate = '.number_format(array_sum($vbr_bitrates) / count($v
 		if ($mpeg_version == 2 && $ratio != 1 && $width != 0) {
 			// Calculate pixel aspect ratio from MPEG-2 display aspect ratio
 			$ratio = $ratio * $height / $width;
-		} else if ($ratio != 0) {
+		} else if ($mpeg_version == 1 && $ratio != 0) {
 			// The MPEG-1 tables store the reciprocal of the pixel aspect ratio.
 			$ratio = 1 / $ratio;
 		}

--- a/getid3/module.audio-video.mpeg.php
+++ b/getid3/module.audio-video.mpeg.php
@@ -621,7 +621,7 @@ echo 'average_File_bitrate = '.number_format(array_sum($vbr_bitrates) / count($v
 		if ($mpeg_version == 2 && $ratio != 1 && $width != 0) {
 			// Calculate pixel aspect ratio from MPEG-2 display aspect ratio
 			$ratio = $ratio * $height / $width;
-		} else if ($mpeg_version == 1 && $ratio != 0) {
+		} else if ($mpeg_version == 1 && $ratio != 0 && !is_nan($ratio)) {
 			// The MPEG-1 tables store the reciprocal of the pixel aspect ratio.
 			$ratio = 1 / $ratio;
 		}


### PR DESCRIPTION
The reciprocal of the actual value was being returned for MPEG-1 video. Files with square pixels were not affected, nor were MPEG-2 files listing a display aspect ratio.

Fixes https://github.com/JamesHeinrich/getID3/issues/410