### PR TITLE
fix: correct IsANumber

### DIFF
--- a/getid3/module.tag.id3v2.php
+++ b/getid3/module.tag.id3v2.php
@@ -3748,23 +3748,16 @@ class getid3_id3v2 extends getid3_handler
 	/**
 	 * @param string $numberstring
 	 * @param bool   $allowdecimal
-	 * @param bool   $allownegative
 	 *
 	 * @return bool
 	 */
-	public static function IsANumber($numberstring, $allowdecimal=false, $allownegative=false) {
-		for ($i = 0; $i < strlen($numberstring); $i++) {
-			if ((chr($numberstring[$i]) < chr('0')) || (chr($numberstring[$i]) > chr('9'))) {
-				if (($numberstring[$i] == '.') && $allowdecimal) {
-					// allowed
-				} elseif (($numberstring[$i] == '-') && $allownegative && ($i == 0)) {
-					// allowed
-				} else {
-					return false;
-				}
-			}
+	public static function IsANumber($numberstring, $allowdecimal=false) {
+		if ($allowdecimal) {
+			$pattern = '/^[0-9.]*$/';
+		} else {
+			$pattern = '/^[0-9]*$/';
 		}
-		return true;
+		return preg_match($pattern, $numberstring) === 1;
 	}
 
 	/**
@@ -3773,7 +3766,7 @@ class getid3_id3v2 extends getid3_handler
 	 * @return bool
 	 */
 	public static function IsValidDateStampString($datestamp) {
-		if (strlen($datestamp) != 8) {
+		if (strlen($datestamp) !== 8) {
 			return false;
 		}
 		if (!self::IsANumber($datestamp, false)) {


### PR DESCRIPTION
The old implementation, using a loop and chr, was incorrect.

$numberstring = '20230528';

$a = chr('2') will return an empty string.
$b = chr('0') will return an empty string.

$a < $b is false.

This was reported by a Nextcloud user here: https://github.com/nextcloud/server/issues/37688

We run a fork version of getID3. I could reproduce the error with your library as well. The user provided the faulty mp3 file. There is apparently no ownership frame, but somehow this code path is executed and it fails when passing an invalid chracter to chr. 

I assume the intention of the original implementation was to check if the character in the range 0-9. 