### PR TITLE
do not crash on empty seconds in DSS module

### DIFF
--- a/getid3/module.audio.dss.php
+++ b/getid3/module.audio.dss.php
@@ -79,12 +79,12 @@ class getid3_dss extends getid3_handler
 	 * @return int|false
 	 */
 	public function DSSdateStringToUnixDate($datestring) {
-		$y = substr($datestring,  0, 2);
-		$m = substr($datestring,  2, 2);
-		$d = substr($datestring,  4, 2);
-		$h = substr($datestring,  6, 2);
-		$i = substr($datestring,  8, 2);
-		$s = substr($datestring, 10, 2);
+		$y = intval(substr($datestring,  0, 2));
+		$m = intval(substr($datestring,  2, 2));
+		$d = intval(substr($datestring,  4, 2));
+		$h = intval(substr($datestring,  6, 2));
+		$i = intval(substr($datestring,  8, 2));
+		$s = intval(substr($datestring, 10, 2));
 		$y += (($y < 95) ? 2000 : 1900);
 		return mktime($h, $i, $s, $m, $d, $y);
 	}


### PR DESCRIPTION
I have had several DSS/DS2 files that caused '[TypeError] mktime(): Argument #3 ($second) must be of type ?int, string given' in module.audio.dss.php in DSSdateStringToUnixDate() function.
After analyzing I found out that the files did not have seconds value in their creation date. So substr returned empty string and empty string passed to mktime() causes TypeError, at least in PHP 8.1 and later.
I have enclosed all substrings in DSSdateStringToUnixDate() with intval() so they are always converted to integers, empty strings to zeros, and mktime() expects integers so it should be more or less correct.
