### PR TITLE
Ignore demos in gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -32,3 +32,4 @@ Doxyfile export-ignore
 phpstan.neon export-ignore
 phpunit.xml.dist export-ignore
 tests/ export-ignore
+demos/ export-ignore


### PR DESCRIPTION
This PR prevents the `demos` directory being included in archives, which Composer uses.

I see that the directory was re-added in [this commit](https://github.com/JamesHeinrich/getID3/commit/a24656a102853b85610acc00237b2e85f41007cf) where the question was asked if it causes any problems.

We use this package as a dependency in our own, and it has been flagged by security analysts because of what's in the demos directory. Excluding the demos directory within gitattributes would prevent it from being included via Composer and would satisfy the requirements.

It looks like the demos are disabled because of security issues anyway:

https://github.com/JamesHeinrich/getID3/blob/d0e347f9d501d184436b1c3dc35d0e7dbfada614/demos/demo.browse.php#L15