### PR TITLE
PHPStan: update to latest version

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -55,4 +55,4 @@ jobs:
           coverage: "none"
       - uses: "ramsey/composer-install@v3"
       - name: "Run PHPStan"
-        run: "phpstan analyse -c phpstan.neon -l 4 getid3"
+        run: "phpstan"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: "shivammathur/setup-php@v2"
         with:
           php-version: "8.2"
-          tools: "phpstan:1.10.57"
+          tools: "phpstan:1.12.3"
           coverage: "none"
       - uses: "ramsey/composer-install@v3"
       - name: "Run PHPStan"

--- a/getid3/module.audio-video.quicktime.php
+++ b/getid3/module.audio-video.quicktime.php
@@ -1650,7 +1650,7 @@ $this->warning('incomplete/incorrect handling of "stsd" with Parrot metadata in 
 						@list($all, $latitude, $longitude, $altitude) = $matches;
 						$info['quicktime']['comments']['gps_latitude'][]  = floatval($latitude);
 						$info['quicktime']['comments']['gps_longitude'][] = floatval($longitude);
-						if (!empty($altitude)) {
+						if (!empty($altitude)) { // @phpstan-ignore-line
 							$info['quicktime']['comments']['gps_altitude'][] = floatval($altitude);
 						}
 					} else {

--- a/getid3/module.audio-video.riff.php
+++ b/getid3/module.audio-video.riff.php
@@ -98,7 +98,7 @@ class getid3_riff extends getid3_handler
 					$info['avdataend'] = $info['filesize'];
 				}
 
-				$nextRIFFoffset = $Original['avdataoffset'] + 8 + $thisfile_riff['header_size']; // 8 = "RIFF" + 32-bit offset
+				$nextRIFFoffset = (int) $Original['avdataoffset'] + 8 + (int) $thisfile_riff['header_size']; // 8 = "RIFF" + 32-bit offset
 				while ($nextRIFFoffset < min($info['filesize'], $info['avdataend'])) {
 					try {
 						$this->fseek($nextRIFFoffset);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,7 @@
 parameters:
+    level: 4
+    paths:
+        - getid3
     excludes_analyse:
     polluteScopeWithLoopInitialAssignments: true
     dynamicConstantNames:


### PR DESCRIPTION
### PHPStan: move CLI options to config

This will make it more intuitive for contributors to run PHPStan locally.

### PHPStan: update to latest version

PHPStan keeps improving and adding more and better checks. Let's use the latest version to get the most benefit from it ;-)

Includes ignoring one newly flagged issue and fixing another.

```
 ------ ---------------------------------------------------------------
  Line   module.audio-video.quicktime.php
 ------ ---------------------------------------------------------------
  1653   Variable $altitude in empty() always exists and is not falsy.
 ------ ---------------------------------------------------------------

 ------ -----------------------------------------------------------------------------------------
  Line   module.audio-video.riff.php
 ------ -----------------------------------------------------------------------------------------
  101    Binary operation "+" between (float|int) and array|float|int|false results in an error.
 ------ -----------------------------------------------------------------------------------------
```