### PR TITLE
GH Actions: PHP 8.4 has been released

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,10 +24,11 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4"
         experimental:
           - false
         include:
-          - php-version: "8.4"
+          - php-version: "8.5"
             experimental: true
             composer-options: "--ignore-platform-reqs"
     steps:


### PR DESCRIPTION
* Builds against PHP 8.4 are no longer allowed to fail.
* Add _allowed to fail_ build against PHP 8.5.

Ref: https://www.php.net/releases/8.4/en.php