### PR TITLE
Use `is_int()` insead of `is_integer()`

### DIFF
--- a/getid3/module.audio-video.quicktime.php
+++ b/getid3/module.audio-video.quicktime.php
@@ -318,7 +318,7 @@ $this->error('HEIF files not currently supported');
 						// some "ilst" atoms contain data atoms that have a numeric name, and the data is far more accessible if the returned array is compacted
 						$allnumericnames = true;
 						foreach ($atom_structure['subatoms'] as $subatomarray) {
-							if (!is_integer($subatomarray['name']) || (count($subatomarray['subatoms']) != 1)) {
+							if (!is_int($subatomarray['name']) || (count($subatomarray['subatoms']) != 1)) {
 								$allnumericnames = false;
 								break;
 							}


### PR DESCRIPTION
[is_integer()](https://www.php.net/manual/en/function.is-integer.php) is an alias for [is_int()](https://www.php.net/manual/en/function.is-int.php). The change updates the type check for atom names to use the more standard `is_int` function instead of `is_integer`, which enhances code consistency and compatibility.


There is a proposal to deprecate `is_integer()` in PHP 8.6, [see RFC](https://wiki.php.net/rfc/deprecations_php_8_6#deprecate_is_integer)
