### PR TITLE
Map RIFF INFO ITRK to track_number (astiga #1294)

### DIFF
--- a/getid3/module.audio-video.riff.php
+++ b/getid3/module.audio-video.riff.php
@@ -2048,6 +2048,7 @@ class getid3_riff extends getid3_handler
 			'ISTD'=>'productionstudio',
 			'ISTR'=>'starring',
 			'ITCH'=>'encoded_by',
+			'ITRK'=>'track_number',
 			'IWEB'=>'url',
 			'IWRI'=>'writer',
 			'____'=>'comment',


### PR DESCRIPTION
Fix for #493  - adds `ITRK` as a mapping field, returns `"track_number"` so that said field appears in `tags*` and `comments*` returns.