### PR TITLE
Guard APE/Lyrics3 against negative seeks on tiny files

### DIFF
--- a/getid3/module.tag.apetag.php
+++ b/getid3/module.tag.apetag.php
@@ -53,21 +53,21 @@ class getid3_apetag extends getid3_handler
 
 		if ($this->overrideendoffset == 0) {
 
-			$this->fseek(0 - $id3v1tagsize - $apetagheadersize - $lyrics3tagsize, SEEK_END);
-			$APEfooterID3v1 = $this->fread($id3v1tagsize + $apetagheadersize + $lyrics3tagsize);
+			// don't seek before the start of the file on tiny files
+			$scanlength = min($id3v1tagsize + $apetagheadersize + $lyrics3tagsize, $info['filesize']);
+			$this->fseek(0 - $scanlength, SEEK_END);
+			$APEfooterID3v1 = $this->fread($scanlength);
+			$buffersize     = strlen($APEfooterID3v1);
 
-			//if (preg_match('/APETAGEX.{24}TAG.{125}$/i', $APEfooterID3v1)) {
-			if (substr($APEfooterID3v1, strlen($APEfooterID3v1) - $id3v1tagsize - $apetagheadersize, 8) == 'APETAGEX') {
+			// APE footer immediately before a trailing ID3v1 tag: /APETAGEX.{24}TAG.{125}$/i
+			$APEbeforeID3v1 = ($buffersize >= ($id3v1tagsize + $apetagheadersize)) && (substr($APEfooterID3v1, $buffersize - $id3v1tagsize - $apetagheadersize, 8) == 'APETAGEX');
+			// APE footer at the very end of the file: /APETAGEX.{24}$/i
+			$APEatEndOfFile = ($buffersize >= $apetagheadersize) && (substr($APEfooterID3v1, $buffersize - $apetagheadersize, 8) == 'APETAGEX');
 
-				// APE tag found before ID3v1
+			if ($APEbeforeID3v1) {
 				$info['ape']['tag_offset_end'] = $info['filesize'] - $id3v1tagsize;
-
-			//} elseif (preg_match('/APETAGEX.{24}$/i', $APEfooterID3v1)) {
-			} elseif (substr($APEfooterID3v1, strlen($APEfooterID3v1) - $apetagheadersize, 8) == 'APETAGEX') {
-
-				// APE tag found, no ID3v1
+			} elseif ($APEatEndOfFile) {
 				$info['ape']['tag_offset_end'] = $info['filesize'];
-
 			}
 
 		} else {

--- a/getid3/module.tag.lyrics3.php
+++ b/getid3/module.tag.lyrics3.php
@@ -32,11 +32,12 @@ class getid3_lyrics3 extends getid3_handler
 			return false;
 		}
 
-		$this->fseek((0 - 128 - 9 - 6), SEEK_END);          // end - ID3v1 - "LYRICSEND" - [Lyrics3size]
+		$scanlength = min(128 + 9 + 6, $info['filesize']); // end - ID3v1 - "LYRICSEND" - [Lyrics3size];
+		$this->fseek(0 - $scanlength, SEEK_END);
 		$lyrics3offset = null;
 		$lyrics3version = null;
 		$lyrics3size   = null;
-		$lyrics3_id3v1 = $this->fread(128 + 9 + 6);
+		$lyrics3_id3v1 = $this->fread($scanlength);
 		$lyrics3lsz    = (int) substr($lyrics3_id3v1, 0, 6); // Lyrics3size
 		$lyrics3end    = substr($lyrics3_id3v1,  6,   9); // LYRICSEND or LYRICS200
 		$id3v1tag      = substr($lyrics3_id3v1, 15, 128); // ID3v1


### PR DESCRIPTION
getid3_apetag and getid3_lyrics3 do seeking by a fixed distance back from EOF. On tiny files this can cause a negative seek to a point before the start of the file when using the analyzer.

This change applies clamping to this negative seek, so that it is never larger than the filesize. There is no real minimum filesize for the scanwindow, as the APE tag can contain multiple/optional elements.

A similar problem was already fixed for id3v1 tags in d721d36.