### PR TITLE
clamp ID3v2 frame read to remaining file size

### DIFF
--- a/getid3/module.tag.id3v2.php
+++ b/getid3/module.tag.id3v2.php
@@ -136,6 +136,7 @@ class getid3_id3v2 extends getid3_handler
 		if (!empty($thisfile_id3v2_flags['isfooter'])) {
 			$sizeofframes -= 10; // footer takes last 10 bytes of ID3v2 header, after frame data, before audio
 		}
+		$sizeofframes = min($sizeofframes, $this->getid3->info['filesize'] - $this->ftell());
 		if ($sizeofframes > 0) {
 
 			$framedata = $this->fread($sizeofframes); // read all frames from file into $framedata variable


### PR DESCRIPTION
An ID3v2 header can declare a tag size far larger than the file. `$sizeofframes` is passed to `fread()` unbounded, so a 10-byte file peaks at ~230 MB =>  memory DoS.

Fix: one liner capping `$sizeofframes` at `filesize - ftell()`.

Buggy example: [poc.mp3](https://github.com/user-attachments/files/31610380/poc.mp3)
